### PR TITLE
Better test hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This is a Ruby Test Explorer extension for the [VS Code Test Explorer](https://m
 
 ![An example screenshot of the extension in use](/img/screenshot.png)
 
-The extension currently only supports Rspec tests.
+The extension currently only supports RSpec tests.
 If someone would like to contribute Minitest support, I'd be willing to merge it, but I probably won't add it myself.
 
 ## Setup
 
-The extension requires that you have Ruby installed along with the `rspec-core` gem (and any other dependencies required by your test suite). It's been tested with Ruby 2.6 and Rspec 3.8, but it should work with most recent versions of Ruby and all versions of Rspec 3.x.
+The extension requires that you have Ruby installed along with the `rspec-core` gem (and any other dependencies required by your test suite). It's been tested with Ruby 2.6 and RSpec 3.8, but it should work with most recent versions of Ruby and all versions of RSpec 3.x.
 
 By default, you need to have `rspec` installed via Bundler with a `Gemfile` and `bundle install`, otherwise `bundle exec rspec` won't work. If you want to run your Rspec tests with a command other than `bundle exec rspec`, you can configure the command with the `rubyTestExplorer.rspecCommand` setting.
 
@@ -23,8 +23,8 @@ Currently supported:
 - Viewing test output for failed tests (click the test in the test explorer sidebar to open the Output view).
 - Displaying test statuses. Success, failure, and pending (called 'skipped' in the extension).
 - File locations for each test.
-- Configurable Rspec command.
-- Some test hierarchy information, unfortunately Rspec makes this a bit of a pain to figure out so the hierarchy is pretty minimal for now.
+- Configurable RSpec command.
+- Some test hierarchy information, unfortunately RSpec makes this a bit of a pain to figure out so the hierarchy is pretty minimal for now.
 
 ## Configuration
 
@@ -34,7 +34,7 @@ Property                            | Description
 ------------------------------------|---------------------------------------------------------------
 `rubyTestExplorer.logpanel`         | Whether to write diagnotic logs to an output panel
 `rubyTestExplorer.logfile`          | Write diagnostic logs to the given file
-`rubyTestExplorer.rspecCommand`     | Define the command to run Rspec tests with, for example `bundle exec rspec`, `spring rspec`, or `rspec`.
+`rubyTestExplorer.rspecCommand`     | Define the command to run RSpec tests with, for example `bundle exec rspec`, `spring rspec`, or `rspec`.
 
 ## TODO
 
@@ -42,7 +42,7 @@ The extension is still in the early stages of development. I intend to improve i
 
 - Run tests in a given file at once, rather than one-at-a-time ([#2](https://github.com/connorshea/vscode-ruby-test-adapter/issues/2))
 - Update test statuses as the tests run ([#3](https://github.com/connorshea/vscode-ruby-test-adapter/issues/3))
-- Create a custom Rspec formatter ([#4](https://github.com/connorshea/vscode-ruby-test-adapter/issues/4))
+- Create a custom RSpec formatter ([#4](https://github.com/connorshea/vscode-ruby-test-adapter/issues/4))
 - Implement a test definitions watcher ([#5](https://github.com/connorshea/vscode-ruby-test-adapter/issues/5))
 - Implement the cancel command ([#6](https://github.com/connorshea/vscode-ruby-test-adapter/issues/6))
 - Organize tests based on their type ([#7](https://github.com/connorshea/vscode-ruby-test-adapter/issues/7))
@@ -57,7 +57,7 @@ You'll need VS Code, Node (any version >= 8 should probably work), and Ruby inst
 - Open the directory in VS Code.
 - Run `npm run watch` or start the `watch` Task in VS Code to get the TypeScript compiler running.
 - Go to the Debug section in the sidebar and run "Ruby adapter". This will start a separate VS Code instance for testing the extension in. It gets updated code whenever "Reload Window" is run in the Command Palette.
-  - You'll need a Ruby project if you want to actually use the extension to run tests, I generally use my project [VideoGameList](https://github.com/connorshea/VideoGameList) for testing, but any Ruby project with Rspec tests will work.
+  - You'll need a Ruby project if you want to actually use the extension to run tests, I generally use my project [VideoGameList](https://github.com/connorshea/VideoGameList) for testing, but any Ruby project with RSpec tests will work.
 
 This extension is based on [the example test adapter](https://github.com/hbenl/vscode-example-test-adapter), it may be useful to check that repository for more information. Test adapters for other languages may also be useful references.
 

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -124,7 +124,7 @@ function getRspecCommand(): string {
 }
 
 function sortTestSuiteChildren(testSuiteChildren: Array<TestSuiteInfo>): Array<TestSuiteInfo> {
-  testSuiteChildren.sort((a: TestSuiteInfo, b: TestSuiteInfo) => {
+  testSuiteChildren = testSuiteChildren.sort((a: TestSuiteInfo, b: TestSuiteInfo) => {
     let comparison = 0;
     if (a.label > b.label) {
       comparison = 1;


### PR DESCRIPTION
Fixes #7. Now tests are organized based on their parent directory.

<img width="334" alt="Screen Shot 2019-05-11 at 4 40 25 PM" src="https://user-images.githubusercontent.com/2977353/57575637-810bb080-740b-11e9-8542-d14341a1f72f.png">

This also adds handling for RSpec errors when trying to load the suite.