### PR TITLE
Fix ActiveSupport#to_json error when test is not wrapped with a string-based describe/context block

### DIFF
--- a/custom_formatter.rb
+++ b/custom_formatter.rb
@@ -105,7 +105,7 @@ class CustomFormatter < RSpec::Core::Formatters::BaseFormatter
       status: example.execution_result.status.to_s,
       file_path: example.metadata[:file_path],
       line_number: example.metadata[:line_number],
-      example_group_description_args: example.metadata[:example_group][:description_args],
+      example_group_description_args: example.metadata[:example_group][:description_args].map(&:to_s),
       type: example.metadata[:type],
       description_args: example.metadata[:description_args],
       pending_message: example.execution_result.pending_message


### PR DESCRIPTION
If you have a top-level test inside a test defined with `describe Klass`, the `:close` step will fail when ActiveSupport attempts to call to_json on a class object. The example group description args only goes up one level, so this error only happens when you have a test at the root of your top-level describe.

ie:

```ruby
  describe Model do
    it "fails to marshal the description args"
    
    describe "with inner group" do
      it "passes"
    end
  end
```

For the first test, `example.metadata[:example_group][:description_args]` will be `[Model(...active record description)]`, instead of a string representation.

This PR simply calls to_s on all example group description args to ensure we are not attempting to call to_json on a Ruby Class