### PR TITLE
Minitest PoC

### DIFF
--- a/custom_formatter.rb
+++ b/custom_formatter.rb
@@ -61,7 +61,7 @@ class CustomFormatter < RSpec::Core::Formatters::BaseFormatter
   end
 
   def close(_notification)
-    output.write "START_OF_RSPEC_JSON#{@output_hash.to_json}END_OF_RSPEC_JSON\n"
+    output.write "START_OF_TEST_JSON#{@output_hash.to_json}END_OF_TEST_JSON\n"
   end
 
   def example_passed(notification)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha512-ddaFSOMuy2Rp97l6q/LEteQygvTQJuEZ+SRhxFKR0uXGsdbFDqX/QF2xoGcOqLQ8XV91v01SnAv2vpgihNgW/Q==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "12.0.0"
       }
     },
     "agent-base": {
@@ -31,7 +31,7 @@
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -40,10 +40,10 @@
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ansi-styles": {
@@ -52,7 +52,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "anymatch": {
@@ -61,8 +61,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "argparse": {
@@ -71,7 +71,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -80,7 +80,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -125,7 +125,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -188,8 +188,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.6.5",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "balanced-match": {
@@ -204,13 +204,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.3.0",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -219,7 +219,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -228,7 +228,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -237,7 +237,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -246,9 +246,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -271,7 +271,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "binary-extensions": {
@@ -292,7 +292,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -302,9 +302,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.3"
       }
     },
     "browser-stdout": {
@@ -331,15 +331,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.3.0",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -362,9 +362,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "cheerio": {
@@ -373,12 +373,12 @@
       "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
       "dev": true,
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.1",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.1",
+        "entities": "1.1.2",
+        "htmlparser2": "3.10.1",
+        "lodash": "4.17.11",
+        "parse5": "3.0.3"
       }
     },
     "chokidar": {
@@ -387,15 +387,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.3",
+        "fsevents": "1.2.9",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1"
       }
     },
     "class-utils": {
@@ -404,10 +404,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -416,7 +416,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -433,8 +433,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -458,7 +458,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -503,17 +503,17 @@
       "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.9.2",
-        "chokidar": "^1.6.0",
-        "duplexer": "^0.1.1",
-        "glob": "^7.0.5",
-        "glob2base": "^0.0.12",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "resolve": "^1.1.7",
-        "safe-buffer": "^5.0.1",
-        "shell-quote": "^1.6.1",
-        "subarg": "^1.0.0"
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "duplexer": "0.1.1",
+        "glob": "7.1.4",
+        "glob2base": "0.0.12",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "resolve": "1.10.1",
+        "safe-buffer": "5.1.2",
+        "shell-quote": "1.6.1",
+        "subarg": "1.0.0"
       }
     },
     "css-select": {
@@ -522,10 +522,10 @@
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.3",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.2"
       }
     },
     "css-what": {
@@ -540,7 +540,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -564,8 +564,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -574,7 +574,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -583,7 +583,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -592,9 +592,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -635,8 +635,8 @@
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
+        "domelementtype": "1.3.1",
+        "entities": "1.1.2"
       }
     },
     "domelementtype": {
@@ -651,7 +651,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.1"
       }
     },
     "domutils": {
@@ -660,8 +660,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.1",
+        "domelementtype": "1.3.1"
       }
     },
     "duplexer": {
@@ -676,8 +676,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "entities": {
@@ -698,7 +698,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.6"
       }
     },
     "escape-string-regexp": {
@@ -713,7 +713,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -722,7 +722,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "extend": {
@@ -737,8 +737,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -747,7 +747,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -758,7 +758,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extsprintf": {
@@ -785,7 +785,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "filename-regex": {
@@ -800,11 +800,11 @@
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.1.1",
+        "repeat-element": "1.1.3",
+        "repeat-string": "1.6.1"
       }
     },
     "find-index": {
@@ -825,7 +825,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -840,9 +840,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.24"
       }
     },
     "fragment-cache": {
@@ -851,7 +851,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fs.realpath": {
@@ -867,8 +867,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "nan": "2.13.2",
+        "node-pre-gyp": "0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -1420,7 +1420,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -1429,12 +1429,12 @@
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -1443,8 +1443,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -1453,7 +1453,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob2base": {
@@ -1462,7 +1462,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "graceful-fs": {
@@ -1489,8 +1489,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.10.0",
+        "har-schema": "2.0.0"
       }
     },
     "has-flag": {
@@ -1505,9 +1505,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -1524,8 +1524,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -1534,7 +1534,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1543,7 +1543,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -1554,7 +1554,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1571,12 +1571,12 @@
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
+        "domelementtype": "1.3.1",
+        "domhandler": "2.4.2",
+        "domutils": "1.5.1",
+        "entities": "1.1.2",
+        "inherits": "2.0.3",
+        "readable-stream": "3.3.0"
       }
     },
     "http-proxy-agent": {
@@ -1585,7 +1585,7 @@
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "4",
+        "agent-base": "4.2.1",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -1606,9 +1606,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "https-proxy-agent": {
@@ -1617,8 +1617,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
+        "agent-base": "4.2.1",
+        "debug": "3.2.6"
       },
       "dependencies": {
         "debug": {
@@ -1627,7 +1627,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -1644,8 +1644,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1659,7 +1659,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-binary-path": {
@@ -1668,7 +1668,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.13.1"
       }
     },
     "is-buffer": {
@@ -1683,7 +1683,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-descriptor": {
@@ -1692,9 +1692,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1717,7 +1717,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -1738,7 +1738,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-number": {
@@ -1747,7 +1747,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-plain-object": {
@@ -1756,7 +1756,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -1860,7 +1860,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "linkify-it": {
@@ -1869,7 +1869,7 @@
       "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
       "dev": true,
       "requires": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "1.0.6"
       }
     },
     "lodash": {
@@ -1890,7 +1890,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "markdown-it": {
@@ -1899,11 +1899,11 @@
       "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~1.1.1",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "argparse": "1.0.10",
+        "entities": "1.1.2",
+        "linkify-it": "2.1.0",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.6"
       }
     },
     "math-random": {
@@ -1924,19 +1924,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -1966,7 +1966,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1981,8 +1981,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -1991,7 +1991,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -2044,12 +2044,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -2064,7 +2064,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -2094,17 +2094,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -2133,7 +2133,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "nth-check": {
@@ -2142,7 +2142,7 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "oauth-sign": {
@@ -2157,9 +2157,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -2168,7 +2168,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -2179,7 +2179,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -2196,8 +2196,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -2206,7 +2206,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -2223,7 +2223,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "os": {
@@ -2250,8 +2250,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "parse-glob": {
@@ -2260,10 +2260,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-semver": {
@@ -2272,7 +2272,7 @@
       "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
       "dev": true,
       "requires": {
-        "semver": "^5.1.0"
+        "semver": "5.7.0"
       }
     },
     "parse5": {
@@ -2281,7 +2281,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "12.0.0"
       }
     },
     "pascalcase": {
@@ -2362,9 +2362,9 @@
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.4"
       },
       "dependencies": {
         "is-number": {
@@ -2387,7 +2387,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.8"
       }
     },
     "readable-stream": {
@@ -2395,9 +2395,9 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
       "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "inherits": "2.0.3",
+        "string_decoder": "1.2.0",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -2406,9 +2406,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.1.15",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "arr-diff": {
@@ -2429,16 +2429,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2447,7 +2447,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2458,13 +2458,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -2473,7 +2473,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -2482,7 +2482,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -2491,7 +2491,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2500,7 +2500,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -2511,7 +2511,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2520,7 +2520,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -2531,9 +2531,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -2550,14 +2550,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -2566,7 +2566,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -2575,7 +2575,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2586,10 +2586,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2598,7 +2598,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2609,7 +2609,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2618,7 +2618,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2627,9 +2627,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -2638,7 +2638,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2647,7 +2647,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -2670,19 +2670,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "readable-stream": {
@@ -2691,13 +2691,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2706,7 +2706,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -2723,7 +2723,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -2732,8 +2732,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "remove-trailing-separator": {
@@ -2760,26 +2760,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.24",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "requires-port": {
@@ -2794,7 +2794,7 @@
       "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-url": {
@@ -2815,7 +2815,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.4"
       }
     },
     "safe-buffer": {
@@ -2829,7 +2829,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -2850,10 +2850,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2862,7 +2862,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2873,10 +2873,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "snapdragon": {
@@ -2885,14 +2885,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2901,7 +2901,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -2910,7 +2910,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2921,9 +2921,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -2932,7 +2932,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -2941,7 +2941,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2950,7 +2950,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2959,9 +2959,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -2984,7 +2984,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "source-map": {
@@ -2999,11 +2999,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -3012,8 +3012,8 @@
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -3036,7 +3036,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "split2": {
@@ -3044,7 +3044,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
       "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
       "requires": {
-        "readable-stream": "^3.0.0"
+        "readable-stream": "3.3.0"
       }
     },
     "sprintf-js": {
@@ -3059,15 +3059,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "static-extend": {
@@ -3076,8 +3076,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -3086,7 +3086,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -3096,7 +3096,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "subarg": {
@@ -3105,7 +3105,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -3122,7 +3122,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "tmp": {
@@ -3131,7 +3131,7 @@
       "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-object-path": {
@@ -3140,7 +3140,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -3149,10 +3149,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -3161,8 +3161,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -3171,7 +3171,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -3182,8 +3182,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.31",
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -3211,7 +3211,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -3254,10 +3254,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3266,7 +3266,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -3275,10 +3275,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -3289,8 +3289,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -3299,9 +3299,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -3335,7 +3335,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -3356,8 +3356,8 @@
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "dev": true,
       "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.1.1",
+        "requires-port": "1.0.0"
       }
     },
     "use": {
@@ -3383,9 +3383,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vsce": {
@@ -3394,26 +3394,26 @@
       "integrity": "sha512-JmVxAO0HtdMjGcdiFPeTbddS//PvO2xVcE7/kq3H1ix3Q4bDyH6j1tSnDDl3OLQkxT/Cgyyqvv/wRohfy6v+lg==",
       "dev": true,
       "requires": {
-        "azure-devops-node-api": "^7.2.0",
-        "chalk": "^2.4.2",
-        "cheerio": "^1.0.0-rc.1",
-        "commander": "^2.8.1",
-        "cpx": "^1.5.0",
-        "denodeify": "^1.2.1",
-        "glob": "^7.0.6",
-        "lodash": "^4.17.10",
-        "markdown-it": "^8.3.1",
-        "mime": "^1.3.4",
-        "minimatch": "^3.0.3",
-        "osenv": "^0.1.3",
-        "parse-semver": "^1.1.1",
-        "read": "^1.0.7",
-        "semver": "^5.1.0",
+        "azure-devops-node-api": "7.2.0",
+        "chalk": "2.4.2",
+        "cheerio": "1.0.0-rc.3",
+        "commander": "2.20.0",
+        "cpx": "1.5.0",
+        "denodeify": "1.2.1",
+        "glob": "7.1.4",
+        "lodash": "4.17.11",
+        "markdown-it": "8.4.2",
+        "mime": "1.6.0",
+        "minimatch": "3.0.4",
+        "osenv": "0.1.5",
+        "parse-semver": "1.1.1",
+        "read": "1.0.7",
+        "semver": "5.7.0",
         "tmp": "0.0.29",
         "typed-rest-client": "1.2.0",
-        "url-join": "^1.1.0",
-        "yauzl": "^2.3.1",
-        "yazl": "^2.2.2"
+        "url-join": "1.1.0",
+        "yauzl": "2.10.0",
+        "yazl": "2.5.1"
       }
     },
     "vscode": {
@@ -3422,13 +3422,13 @@
       "integrity": "sha512-GuT3tCT2N5Qp26VG4C+iGmWMgg/MuqtY5G5TSOT3U/X6pgjM9LFulJEeqpyf6gdzpI4VyU3ZN/lWPo54UFPuQg==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.2",
-        "mocha": "^4.0.1",
-        "request": "^2.88.0",
-        "semver": "^5.4.1",
-        "source-map-support": "^0.5.0",
-        "url-parse": "^1.4.4",
-        "vscode-test": "^0.4.1"
+        "glob": "7.1.4",
+        "mocha": "4.1.0",
+        "request": "2.88.0",
+        "semver": "5.7.0",
+        "source-map-support": "0.5.12",
+        "url-parse": "1.4.7",
+        "vscode-test": "0.4.1"
       }
     },
     "vscode-test": {
@@ -3437,8 +3437,8 @@
       "integrity": "sha512-uIi/07uG/gmCbD9Y9bFpNzmk4el82xiclijEdL426A3jOFfvwdqgfmtuWYfxEGo0w6JY9EqVDTGQCXwuInXVTQ==",
       "dev": true,
       "requires": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1"
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1"
       }
     },
     "vscode-test-adapter-api": {
@@ -3451,8 +3451,8 @@
       "resolved": "https://registry.npmjs.org/vscode-test-adapter-util/-/vscode-test-adapter-util-0.7.0.tgz",
       "integrity": "sha512-eAsB8koXct5JytvUcV62wLEBCQfsoclauzMLEFT6H0qBr1h8LyRc+dGDcs48pO28yFOo6VV+5AwCRLxTKh7TzQ==",
       "requires": {
-        "tslib": "^1.9.3",
-        "vscode-test-adapter-api": "^1.7.0"
+        "tslib": "1.9.3",
+        "vscode-test-adapter-api": "1.7.0"
       }
     },
     "wrappy": {
@@ -3467,8 +3467,8 @@
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.1.0"
       }
     },
     "yazl": {
@@ -3477,7 +3477,7 @@
       "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3"
+        "buffer-crc32": "0.2.13"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "img/ruby-test-explorer.png",
   "author": "Connor Shea <connor.james.shea@gmail.com>",
   "publisher": "connorshea",
-  "version": "0.5.0",
+  "version": "0.4.6",
   "license": "MIT",
   "homepage": "https://github.com/connorshea/vscode-ruby-test-adapter",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -73,17 +73,17 @@
       "title": "Ruby Test Explorer configuration",
       "properties": {
         "rubyTestExplorer.logpanel": {
-          "description": "Write diagnotic logs to an output panel",
+          "description": "Write diagnotic logs to an output panel.",
           "type": "boolean",
           "scope": "resource"
         },
         "rubyTestExplorer.logfile": {
-          "description": "Write diagnostic logs to the given file",
+          "description": "Write diagnostic logs to the given file.",
           "type": "string",
           "scope": "resource"
         },
         "rubyTestExplorer.testFramework": {
-          "description": "Test framework to use by default, for example rspec or minitest",
+          "description": "Test framework to use by default, for example rspec or minitest.",
           "type": "string",
           "default": "auto",
           "enum": [
@@ -112,8 +112,8 @@
           "type": "string",
           "scope": "resource"
         },
-        "rubyTestExplorer.rakeCommand": {
-          "markdownDescription": "Define how to run rake: `./bin/rake`, bundle exec rake` or `rake`.",
+        "rubyTestExplorer.minitestCommand": {
+          "markdownDescription": "Define how to run Minitest with Rake, for example `./bin/rake`, bundle exec rake` or `rake`.",
           "default": "bundle exec rake",
           "type": "string",
           "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -83,10 +83,21 @@
           "scope": "resource"
         },
         "rubyTestExplorer.testFramework": {
-          "description": "Framework used for testing (ex: rspec, minitest)",
+          "description": "Test framework to use by default, for example rspec or minitest",
           "type": "string",
-          "default": "none",
-          "enum": ["none", "rspec", "minitest"],
+          "default": "auto",
+          "enum": [
+            "none",
+            "auto",
+            "rspec",
+            "minitest"
+          ],
+          "enumDescriptions": [
+            "Disable Ruby Test Runner.",
+            "Automatically detect test framework for a given workspace using Bundler.",
+            "Use RSpec test framework.",
+            "Use Minitest test framework."
+          ],
           "scope": "resource"
         },
         "rubyTestExplorer.rspecCommand": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "img/ruby-test-explorer.png",
   "author": "Connor Shea <connor.james.shea@gmail.com>",
   "publisher": "connorshea",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "license": "MIT",
   "homepage": "https://github.com/connorshea/vscode-ruby-test-adapter",
   "repository": {
@@ -22,6 +22,8 @@
     "test",
     "testing",
     "rspec",
+    "minitest",
+    "mini_test",
     "ruby",
     "test explorer",
     "test adapter"
@@ -62,7 +64,8 @@
     "onLanguage:erb",
     "workspaceContains:**/Rakefile",
     "workspaceContains:**/Gemfile",
-    "workspaceContains:**/*.rb"
+    "workspaceContains:**/*.rb",
+    "onCommand:commandId"
   ],
   "contributes": {
     "configuration": {
@@ -79,6 +82,13 @@
           "type": "string",
           "scope": "resource"
         },
+        "rubyTestExplorer.testingFramework": {
+          "description": "Framework used for testing (ex: rspec, minitest)",
+          "type": "string",
+          "default": "none",
+          "enum": ["none", "rspec", "minitest"],
+          "scope": "resource"
+        },
         "rubyTestExplorer.rspecCommand": {
           "markdownDescription": "Define the command to run Rspec tests with, for example `bundle exec rspec`, `spring rspec`, or `rspec`.",
           "default": "bundle exec rspec",
@@ -88,6 +98,18 @@
         "rubyTestExplorer.specDirectory": {
           "markdownDescription": "The location of your spec directory relative to the root of the workspace.",
           "default": "./spec/",
+          "type": "string",
+          "scope": "resource"
+        },
+        "rubyTestExplorer.rakeCommand": {
+          "markdownDescription": "Define how to run rake: `./bin/rake`, bundle exec rake` or `rake`.",
+          "default": "bundle exec rake",
+          "type": "string",
+          "scope": "resource"
+        },
+        "rubyTestExplorer.minitestDirectory": {
+          "markdownDescription": "The location of your test directory relative to the root of the workspace.",
+          "default": "./test/",
           "type": "string",
           "scope": "resource"
         }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
           "type": "string",
           "scope": "resource"
         },
-        "rubyTestExplorer.testingFramework": {
+        "rubyTestExplorer.testFramework": {
           "description": "Framework used for testing (ex: rspec, minitest)",
           "type": "string",
           "default": "none",

--- a/ruby/vscode.rake
+++ b/ruby/vscode.rake
@@ -8,7 +8,7 @@ namespace :vscode do
       VSCode::Minitest.list
     end
 
-    desc "Run tests (accepts one or more files, folders or file:line formats"
+    desc "Run tests (accepts one or more files, folders or file:line formats)"
     task :run do |t|
       args = ARGV.dup.drop_while { |a| a != t.name }.drop(1)
       VSCode::Minitest.run(*args)

--- a/ruby/vscode.rake
+++ b/ruby/vscode.rake
@@ -1,0 +1,17 @@
+$LOAD_PATH << File.expand_path('..', __FILE__)
+require "vscode/minitest"
+
+namespace :vscode do
+  namespace :minitest do
+    desc "List minitest available tests"
+    task :list do
+      VSCode::Minitest.list
+    end
+
+    desc "Run tests (accepts one or more files, folders or file:line formats"
+    task :run do |t|
+      args = ARGV.dup.drop_while { |a| a != t.name }.drop(1)
+      VSCode::Minitest.run(*args)
+    end
+  end
+end

--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -25,7 +25,7 @@ module VSCode
     end
 
     def run(*args)
-      args = ["./test/"] if args.empty?
+      args = [ENV['TESTS_DIR']] if args.empty?
       reporter = Reporter.new
       reporter.start
       runner = Runner.new(reporter: reporter)

--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -17,10 +17,11 @@ module VSCode
   module Minitest
     module_function
 
-    def list
+    def list(io = $stdout)
+      io.sync = true if io.respond_to?(:"sync=")
       data = { version: ::Minitest::VERSION, examples: tests.all }
       json = ENV.key?("PRETTY") ? JSON.pretty_generate(data.as_json) : JSON.generate(data.as_json)
-      puts "START_OF_TEST_JSON#{json}END_OF_TEST_JSON"
+      io.puts "START_OF_TEST_JSON#{json}END_OF_TEST_JSON"
     end
 
     def run(*args)

--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -1,0 +1,40 @@
+require "vscode/minitest/tests"
+require "vscode/minitest/reporter"
+require "vscode/minitest/runner"
+
+module Minitest
+  # we don't want tests to autorun
+  def self.autorun
+  end
+end
+
+module VSCode
+  module_function
+  def project_root
+    @project_root ||= Pathname.new(Dir.pwd)
+  end
+
+  module Minitest
+    module_function
+
+    def list
+      data = { version: ::Minitest::VERSION, examples: tests.all }
+      puts "START_OF_MINITEST_JSON#{JSON.generate(data.as_json)}END_OF_MINITEST_JSON"
+    end
+
+    def run(*args)
+      args = ["./test/"] if args.empty?
+      reporter = Reporter.new
+      reporter.start
+      runner = Runner.new(reporter: reporter)
+      args.each { |arg| runner.add(arg) }
+      runner.run
+      reporter.report
+      exit(reporter.passed?)
+    end
+
+    def tests
+      @tests ||= Tests.new
+    end
+  end
+end

--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -19,7 +19,8 @@ module VSCode
 
     def list
       data = { version: ::Minitest::VERSION, examples: tests.all }
-      puts "START_OF_MINITEST_JSON#{JSON.generate(data.as_json)}END_OF_MINITEST_JSON"
+      json = ENV.key?("PRETTY") ? JSON.pretty_generate(data.as_json) : JSON.generate(data.as_json)
+      puts "START_OF_MINITEST_JSON#{json}END_OF_MINITEST_JSON"
     end
 
     def run(*args)

--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -20,7 +20,7 @@ module VSCode
     def list
       data = { version: ::Minitest::VERSION, examples: tests.all }
       json = ENV.key?("PRETTY") ? JSON.pretty_generate(data.as_json) : JSON.generate(data.as_json)
-      puts "START_OF_MINITEST_JSON#{json}END_OF_MINITEST_JSON"
+      puts "START_OF_TEST_JSON#{json}END_OF_TEST_JSON"
     end
 
     def run(*args)

--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -30,7 +30,7 @@ module VSCode
         self.errors     = aggregate[::Minitest::UnexpectedError].size
         self.skips      = aggregate[::Minitest::Skip].size
         json = ENV.key?("PRETTY") ? JSON.pretty_generate(vscode_data.as_json) : JSON.generate(vscode_data.as_json)
-        io.puts "START_OF_MINITEST_JSON#{json}END_OF_MINITEST_JSON"
+        io.puts "START_OF_TEST_JSON#{json}END_OF_TEST_JSON"
       end
 
       def passed?

--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -14,7 +14,7 @@ module VSCode
         self.start_time = ::Minitest.clock_time
       end
 
-      def record result
+      def record(result)
         self.count += 1
         self.assertions += result.assertions
         results << result

--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -1,0 +1,70 @@
+module VSCode
+  module Minitest
+    class Reporter < ::Minitest::Reporter
+      attr_accessor :assertions, :count, :results, :start_time, :total_time, :failures, :errors, :skips
+
+      def initialize(io = $stdout, options = {})
+        super
+        self.assertions = 0
+        self.count      = 0
+        self.results    = []
+      end
+
+      def start
+        self.start_time = ::Minitest.clock_time
+      end
+
+      def record result
+        self.count += 1
+        self.assertions += result.assertions
+        results << result
+        data = vscode_result(result)
+        io.puts "\n#{data[:status].upcase}: #{data[:id]}\n"
+      end
+
+      def report
+        aggregate = results.group_by { |r| r.failure.class }
+        aggregate.default = [] # dumb. group_by should provide this
+        self.total_time = (::Minitest.clock_time - start_time).round(2)
+        self.failures   = aggregate[::Minitest::Assertion].size
+        self.errors     = aggregate[::Minitest::UnexpectedError].size
+        self.skips      = aggregate[::Minitest::Skip].size
+        io.puts "START_OF_MINITEST_JSON#{JSON.generate(vscode_data.as_json)}END_OF_MINITEST_JSON"
+      end
+
+      def passed?
+        failures == 0
+      end
+
+      def vscode_data
+        {
+          version: ::Minitest::VERSION,
+          summary: { duration: total_time, example_count: assertions, failure_count: failures, pending_count: skips, errors_outside_of_examples_count: errors },
+          summary_line: "Total time: #{total_time}, Runs: #{count}, Assertions: #{assertions}, Failures: #{failures}, Errors: #{errors}, Skips: #{skips}",
+          examples: results.map { |r| vscode_result(r) }
+        }
+      end
+
+      def vscode_result(r)
+        base = VSCode::Minitest.tests.find_by(klass: r.klass, method: r.name).deep_dup
+        if r.skipped?
+          base[:status] = "failed"
+          base[:pending_message] = r.failure.message
+        elsif r.passed?
+          base[:status] = "passed"
+        else
+          base[:status] = "failed"
+          base[:pending_message] = nil
+          e = r.failure.exception
+          base[:exception] = {
+            class: e.class.name,
+            message: e.message,
+            backtrace: Rails::BacktraceCleaner.new.clean(e.backtrace),
+            full_backtrace: e.backtrace
+          }
+        end
+        base
+      end
+    end
+  end
+end

--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -50,7 +50,13 @@ module VSCode
       def vscode_data
         {
           version: ::Minitest::VERSION,
-          summary: { duration: total_time, example_count: assertions, failure_count: failures, pending_count: skips, errors_outside_of_examples_count: errors },
+          summary: {
+            duration: total_time,
+            example_count: assertions,
+            failure_count: failures,
+            pending_count: skips,
+            errors_outside_of_examples_count: errors
+          },
           summary_line: "Total time: #{total_time}, Runs: #{count}, Assertions: #{assertions}, Failures: #{failures}, Errors: #{errors}, Skips: #{skips}",
           examples: results.map { |r| vscode_result(r) }
         }

--- a/ruby/vscode/minitest/runner.rb
+++ b/ruby/vscode/minitest/runner.rb
@@ -1,0 +1,45 @@
+module VSCode
+  module Minitest
+    class Runner
+      attr_reader :reporter, :runnables
+
+      def initialize(reporter:)
+        @reporter = reporter
+        @runnables = []
+      end
+
+      def add(runnable)
+        path, line = runnable.split(":")
+        path = File.expand_path(path, VSCode.project_root)
+        return add_dir(path) if File.directory?(path)
+        return add_file_with_line(path, line.to_i) if File.file?(path) && line
+        return add_file(path) if File.file?(path)
+        raise "Can't add #{runnable.inspect}"
+      end
+
+      def add_dir(path)
+        Rake::FileList["#{path}/**/*_test.rb"].each do |file|
+          add_file(file)
+        end
+      end
+
+      def add_file(file)
+        test = VSCode::Minitest.tests.find_by(full_path: file)
+        runnables << [test[:klass].constantize, {}] if test
+      end
+
+      def add_file_with_line(file, line)
+        test = VSCode::Minitest.tests.find_by(full_path: file, line_number: line)
+        raise "There is no test the the given location: #{file}:#{line}" unless test
+        runnables << [test[:klass].constantize, filter: test[:method]]
+      end
+
+
+      def run
+        runnables.each do |runnable, options|
+          runnable.run(reporter, options)
+        end
+      end
+    end
+  end
+end

--- a/ruby/vscode/minitest/runner.rb
+++ b/ruby/vscode/minitest/runner.rb
@@ -34,7 +34,6 @@ module VSCode
         runnables << [test[:klass].constantize, filter: test[:method]]
       end
 
-
       def run
         runnables.each do |runnable, options|
           runnable.run(reporter, options)

--- a/ruby/vscode/minitest/tests.rb
+++ b/ruby/vscode/minitest/tests.rb
@@ -15,8 +15,11 @@ module VSCode
       end
 
       def load_files
-        $LOAD_PATH << VSCode.project_root.join("test").to_s
-        Rake::FileList["test/**/*_test.rb"].each { |path| require File.expand_path(path) }
+        # Take the tests dir in the format of `./test/` and turn it into `test`.
+        test_dir = ENV['TESTS_DIR'].gsub('./', '')
+        test_dir = test_dir[0...-1] if test_dir.end_with?('/')
+        $LOAD_PATH << VSCode.project_root.join(test_dir).to_s
+        Rake::FileList["#{test_dir}/**/*_test.rb"].each { |path| require File.expand_path(path) }
       end
 
       def build_list
@@ -28,8 +31,13 @@ module VSCode
             path = full_path.gsub(VSCode.project_root.to_s, ".")
             path = "./#{path}" unless path =~ /^\./
             {
-              description: test_name.gsub(/^test_/, "").gsub("_", " "), full_description: test_name.gsub(/^test_/, "").gsub("_", " "),
-              file_path: path, full_path: full_path, line_number: line, klass: runnable.name, method: test_name
+              description: test_name.gsub(/^test_/, "").gsub("_", " "),
+              full_description: test_name.gsub(/^test_/, "").gsub("_", " "),
+              file_path: path,
+              full_path: full_path,
+              line_number: line,
+              klass: runnable.name,
+              method: test_name
             }
           end
           file_tests.sort_by! { |t| t[:line_number] }

--- a/ruby/vscode/minitest/tests.rb
+++ b/ruby/vscode/minitest/tests.rb
@@ -1,0 +1,45 @@
+module VSCode
+  module Minitest
+    class Tests
+      def all
+        @all ||= begin
+          load_files
+          build_list
+        end
+      end
+
+      def find_by(**filters)
+        all.find do |test|
+          test.values_at(*filters.keys) == filters.values
+        end
+      end
+
+      def load_files
+        $LOAD_PATH << VSCode.project_root.join("test").to_s
+        Rake::FileList["test/**/*_test.rb"].each { |path| require File.expand_path(path) }
+      end
+
+      def build_list
+        tests = []
+        ::Minitest::Runnable.runnables.map do |runnable|
+          file_tests = runnable.runnable_methods.map do |test_name|
+            path, line = runnable.instance_method(test_name).source_location
+            full_path = File.expand_path(path, VSCode.project_root)
+            path = full_path.gsub(VSCode.project_root.to_s, ".")
+            path = "./#{path}" unless path =~ /^\./
+            {
+              description: test_name.gsub(/^test_/, "").gsub("_", " "), full_description: test_name.gsub(/^test_/, "").gsub("_", " "),
+              file_path: path, full_path: full_path, line_number: line, klass: runnable.name, method: test_name
+            }
+          end
+          file_tests.sort_by! { |t| t[:line_number] }
+          file_tests.each_with_index do |t, index|
+            t[:id]= "#{t[:file_path]}[1:1:#{index + 1}]"
+          end
+          tests.concat(file_tests)
+        end
+        tests
+      end
+    end
+  end
+end

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -42,6 +42,9 @@ export class RubyAdapter implements TestAdapter {
       this.testsInstance = new MinitestTests(this.context, this.testStatesEmitter, this.log);
       const loadedTests = await this.testsInstance.loadTests();
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: loadedTests });
+    } else {
+      this.log.warn('No test framework selected. Configure the rubyTestExplorer.testingFramework setting if you want to use the Ruby Test Explorer.');
+      this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished' });
     }
   }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -44,7 +44,7 @@ export class RubyAdapter implements TestAdapter {
       const loadedTests = await this.testsInstance.loadTests();
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: loadedTests });
     } else {
-      this.log.warn('No test framework selected. Configure the rubyTestExplorer.testingFramework setting if you want to use the Ruby Test Explorer.');
+      this.log.warn('No test framework selected. Configure the rubyTestExplorer.testFramework setting if you want to use the Ruby Test Explorer.');
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished' });
     }
   }
@@ -83,7 +83,7 @@ export class RubyAdapter implements TestAdapter {
   }
 
   private getTestFramework(): string {
-    let testFramework: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('testingFramework') as string);
+    let testFramework: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('testFramework') as string);
     return testFramework || 'none';
   }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -36,7 +36,7 @@ export class RubyAdapter implements TestAdapter {
       const loadedTests = await this.rspecTestsInstance.loadRspecTests();
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: loadedTests });
     }
-    if (this.getTestingFramework() == "rspec") {
+    else if (this.getTestingFramework() === "rspec") {
       this.rspecTestsInstance = new RspecTests(this.context, this.testStatesEmitter, this.log);
       const loadedTests = await this.rspecTestsInstance.loadRspecTests();
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: loadedTests });

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -31,7 +31,7 @@ export class RubyAdapter implements TestAdapter {
   async load(): Promise<void> {
     this.log.info('Loading Ruby tests');
     this.testsEmitter.fire(<TestLoadStartedEvent>{ type: 'started' });
-    if(this.getTestingFramework() == "minitest") {
+    if (this.getTestingFramework() === "minitest") {
       this.rspecTestsInstance = new MinitestTests(this.context, this.testStatesEmitter, this.log);
       const loadedTests = await this.rspecTestsInstance.loadRspecTests();
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: loadedTests });

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { TestAdapter, TestLoadStartedEvent, TestLoadFinishedEvent, TestRunStartedEvent, TestRunFinishedEvent, TestSuiteEvent, TestEvent } from 'vscode-test-adapter-api';
 import { Log } from 'vscode-test-adapter-util';
+import { Tests } from './tests';
 import { RspecTests } from './rspecTests';
 import { MinitestTests } from './minitestTests';
 
@@ -10,7 +11,7 @@ export class RubyAdapter implements TestAdapter {
   private readonly testsEmitter = new vscode.EventEmitter<TestLoadStartedEvent | TestLoadFinishedEvent>();
   private readonly testStatesEmitter = new vscode.EventEmitter<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent>();
   private readonly autorunEmitter = new vscode.EventEmitter<void>();
-  private testsInstance: RspecTests | undefined;
+  private testsInstance: Tests | undefined;
 
   get tests(): vscode.Event<TestLoadStartedEvent | TestLoadFinishedEvent> { return this.testsEmitter.event; }
   get testStates(): vscode.Event<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent> { return this.testStatesEmitter.event; }
@@ -34,12 +35,12 @@ export class RubyAdapter implements TestAdapter {
     if (this.getTestingFramework() === "rspec") {
       this.log.info('Loading RSpec tests...');
       this.testsInstance = new RspecTests(this.context, this.testStatesEmitter, this.log);
-      const loadedTests = await this.testsInstance.loadRspecTests();
+      const loadedTests = await this.testsInstance.loadTests();
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: loadedTests });
     } else if (this.getTestingFramework() === "minitest") {
       this.log.info('Loading Minitest tests...');
       this.testsInstance = new MinitestTests(this.context, this.testStatesEmitter, this.log);
-      const loadedTests = await this.testsInstance.loadRspecTests();
+      const loadedTests = await this.testsInstance.loadTests();
       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: loadedTests });
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,9 @@ export async function activate(context: vscode.ExtensionContext) {
     log.info(`Test Explorer ${testExplorerExtension ? '' : 'not '}found`);
   }
 
-  if (testExplorerExtension) {
+  let testingFramework: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('testingFramework') as string) || 'none';
+
+  if (testExplorerExtension && testingFramework != "none") {
     const testHub = testExplorerExtension.exports;
 
     // this will register a RubyTestAdapter for each WorkspaceFolder

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   let testingFramework: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('testingFramework') as string) || 'none';
 
-  if (testExplorerExtension && testingFramework != "none") {
+  if (testExplorerExtension && testingFramework !== "none") {
     const testHub = testExplorerExtension.exports;
 
     // this will register a RubyTestAdapter for each WorkspaceFolder

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,9 +17,9 @@ export async function activate(context: vscode.ExtensionContext) {
     log.info(`Test Explorer ${testExplorerExtension ? '' : 'not '}found`);
   }
 
-  let testingFramework: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('testingFramework') as string) || 'none';
+  let testFramework: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('testFramework') as string) || 'none';
 
-  if (testExplorerExtension && testingFramework !== "none") {
+  if (testExplorerExtension && testFramework !== "none") {
     const testHub = testExplorerExtension.exports;
 
     // this will register a RubyTestAdapter for each WorkspaceFolder

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { TestSuiteInfo, TestInfo, TestRunFinishedEvent, TestSuiteEvent, TestEvent } from 'vscode-test-adapter-api';
+import { TestSuiteInfo, TestInfo, TestRunFinishedEvent, TestEvent } from 'vscode-test-adapter-api';
 import * as childProcess from 'child_process';
 import * as split2 from 'split2';
 import { Tests } from './tests';
@@ -10,10 +10,10 @@ export class MinitestTests extends Tests {
    *
    * @return The RSpec test suite as a TestSuiteInfo object.
    */
-  rspecTests = async () => new Promise<TestSuiteInfo>((resolve, reject) => {
+  tests = async () => new Promise<TestSuiteInfo>((resolve, reject) => {
     try {
       // If test suite already exists, use testSuite. Otherwise, load them.
-      let rspecTests = this.testSuite ? this.testSuite : this.loadRspecTests();
+      let rspecTests = this.testSuite ? this.testSuite : this.loadTests();
       return resolve(rspecTests);
     } catch (err) {
       this.log.error(`Error while attempting to load RSpec tests: ${err.message}`);
@@ -57,7 +57,7 @@ export class MinitestTests extends Tests {
    *
    * @return The full RSpec test suite.
    */
-  public async loadRspecTests(): Promise<TestSuiteInfo> {
+  public async loadTests(): Promise<TestSuiteInfo> {
     let output = await this.initRspecTests();
     this.log.debug('Passing raw output from dry-run into getJsonFromOutput.');
     this.log.debug(`${output}`);
@@ -86,8 +86,8 @@ export class MinitestTests extends Tests {
       // sort properly relative to everything else.
       (suite.children as Array<TestInfo>).sort((a: TestInfo, b: TestInfo) => {
         if ((a as TestInfo).type === "test" && (b as TestInfo).type === "test") {
-          let aLocation: number = this.getTestLocation(a as TestInfo);
-          let bLocation: number = this.getTestLocation(b as TestInfo);
+          let aLocation: number = super.getTestLocation(a as TestInfo);
+          let bLocation: number = super.getTestLocation(b as TestInfo);
           return aLocation - bLocation;
         } else {
           return 0;
@@ -108,20 +108,6 @@ export class MinitestTests extends Tests {
       this.currentChildProcess.kill();
       this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
     }
-  }
-
-  /**
-   * Get the location of the test in the testing tree.
-   *
-   * Test ids are in the form of `/spec/model/game_spec.rb[1:1:1]`, and this
-   * function turns that into `111`. The number is used to order the tests
-   * in the explorer.
-   *
-   * @param test The test we want to get the location of.
-   * @return A number representing the location of the test in the test tree.
-   */
-  protected getTestLocation(test: TestInfo): number {
-    return parseInt(test.id.substring(test.id.indexOf("[") + 1, test.id.lastIndexOf("]")).split(':').join(''));
   }
 
   /**
@@ -427,7 +413,7 @@ export class MinitestTests extends Tests {
   /**
    * Runs tests in a given file.
    *
-   * @param testFile The test file's file path, e.g. `/path/to/spec.rb`.
+   * @param testFile The test file's file path, e.g. `/path/to/test.rb`.
    * @return The raw output from running the tests.
    */
   runTestFile = async (testFile: string) => new Promise<string>(async (resolve, reject) => {
@@ -476,29 +462,11 @@ export class MinitestTests extends Tests {
   });
 
   /**
-   * Runs the test suite by iterating through each test and running it.
-   *
-   * @param tests
-   */
-  runTests = async (
-    tests: string[]
-  ): Promise<void> => {
-    let testSuite: TestSuiteInfo = await this.rspecTests();
-
-    for (const suiteOrTestId of tests) {
-      const node = this.findNode(testSuite, suiteOrTestId);
-      if (node) {
-        await this.runNode(node);
-      }
-    }
-  }
-
-  /**
-   * Handles test state based on the output returned by the custom RSpec formatter.
+   * Handles test state based on the output returned by the Minitest Rake task.
    *
    * @param test The test that we want to handle.
    */
-  protected handleStatus(test: any): void {
+  handleStatus(test: any): void {
     this.log.debug(`Handling status of test: ${JSON.stringify(test)}`);
     if (test.status === "passed") {
       this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: test.id, state: 'passed' });

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -1,21 +1,21 @@
 import * as vscode from 'vscode';
-import { TestSuiteInfo, TestInfo, TestEvent } from 'vscode-test-adapter-api';
+import { TestSuiteInfo, TestEvent } from 'vscode-test-adapter-api';
 import * as childProcess from 'child_process';
 import { Tests } from './tests';
 
 export class MinitestTests extends Tests {
   /**
-   * Representation of the RSpec test suite as a TestSuiteInfo object.
+   * Representation of the Minitest test suite as a TestSuiteInfo object.
    *
-   * @return The RSpec test suite as a TestSuiteInfo object.
+   * @return The Minitest test suite as a TestSuiteInfo object.
    */
   tests = async () => new Promise<TestSuiteInfo>((resolve, reject) => {
     try {
       // If test suite already exists, use testSuite. Otherwise, load them.
-      let rspecTests = this.testSuite ? this.testSuite : this.loadTests();
-      return resolve(rspecTests);
+      let minitestTests = this.testSuite ? this.testSuite : this.loadTests();
+      return resolve(minitestTests);
     } catch (err) {
-      this.log.error(`Error while attempting to load RSpec tests: ${err.message}`);
+      this.log.error(`Error while attempting to load Minitest tests: ${err.message}`);
       return reject(err);
     }
   });
@@ -23,10 +23,10 @@ export class MinitestTests extends Tests {
   /**
    * Perform a dry-run of the test suite to get information about every test.
    *
-   * @return The raw output from the RSpec JSON formatter.
+   * @return The raw output from the Minitest JSON formatter.
    */
-  initRspecTests = async () => new Promise<string>((resolve, reject) => {
-    let cmd = `${this.getRspecCommand()} vscode:minitest:list`;
+  initTests = async () => new Promise<string>((resolve, reject) => {
+    let cmd = `${this.getTestCommand()} vscode:minitest:list`;
 
     // Allow a buffer of 64MB.
     const execArgs: childProcess.ExecOptions = {
@@ -35,14 +35,14 @@ export class MinitestTests extends Tests {
       env: this.getProcessEnv()
     };
 
-    this.log.info(`Running dry-run of Minitest test suite with the following command: ${cmd}`);
+    this.log.info(`Getting a list of Minitest tests in suite with the following command: ${cmd}`);
 
     childProcess.exec(cmd, execArgs, (err, stdout) => {
       if (err) {
-        this.log.error(`Error while finding RSpec test suite: ${err.message}`);
+        this.log.error(`Error while finding Minitest test suite: ${err.message}`);
         this.log.error(`Output: ${stdout}`);
         // Show an error message.
-        vscode.window.showWarningMessage("Ruby Test Explorer failed to find an RSpec test suite. Make sure RSpec is installed and your configured RSpec command is correct.");
+        vscode.window.showWarningMessage("Ruby Test Explorer failed to find a Minitest test suite. Make sure Minitest is installed and your configured Minitest command is correct.");
         vscode.window.showErrorMessage(err.message);
         throw err;
       }
@@ -51,60 +51,11 @@ export class MinitestTests extends Tests {
   });
 
   /**
-   * Takes the output from initRSpecTests() and parses the resulting
-   * JSON into a TestSuiteInfo object.
+   * Get the user-configured Minitest command, if there is one.
    *
-   * @return The full RSpec test suite.
+   * @return The Minitest command
    */
-  public async loadTests(): Promise<TestSuiteInfo> {
-    let output = await this.initRspecTests();
-    this.log.debug('Passing raw output from dry-run into getJsonFromOutput.');
-    this.log.debug(`${output}`);
-    output = super.getJsonFromOutput(output);
-    this.log.debug('Parsing the below JSON:');
-    this.log.debug(`${output}`);
-    let rspecMetadata = JSON.parse(output);
-
-    let tests: Array<{ id: string; full_description: string; description: string; file_path: string; line_number: number; location: number; }> = [];
-
-    rspecMetadata.examples.forEach((test: { id: string; full_description: string; description: string; file_path: string; line_number: number; location: number; }) => {
-      let test_location_array: Array<string> = test.id.substring(test.id.indexOf("[") + 1, test.id.lastIndexOf("]")).split(':');
-      let test_location_string: string = test_location_array.join('');
-      test.location = parseInt(test_location_string);
-
-      tests.push(test);
-    });
-
-    let testSuite: TestSuiteInfo = await this.getBaseTestSuite(tests);
-
-    // Sort the children of each test suite based on their location in the test tree.
-    (testSuite.children as Array<TestSuiteInfo>).forEach((suite: TestSuiteInfo) => {
-      // NOTE: This will only sort correctly if everything is nested at the same
-      // level, e.g. 111, 112, 121, etc. Once a fourth level of indentation is
-      // introduced, the location is generated as e.g. 1231, which won't
-      // sort properly relative to everything else.
-      (suite.children as Array<TestInfo>).sort((a: TestInfo, b: TestInfo) => {
-        if ((a as TestInfo).type === "test" && (b as TestInfo).type === "test") {
-          let aLocation: number = super.getTestLocation(a as TestInfo);
-          let bLocation: number = super.getTestLocation(b as TestInfo);
-          return aLocation - bLocation;
-        } else {
-          return 0;
-        }
-      })
-    });
-
-    this.testSuite = testSuite;
-
-    return Promise.resolve<TestSuiteInfo>(testSuite);
-  }
-
-  /**
-   * Get the user-configured RSpec command, if there is one.
-   *
-   * @return The RSpec command
-   */
-  protected getRspecCommand(): string {
+  protected getTestCommand(): string {
     let command: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('rakeCommand') as string) || 'bundle exec rake';
     return `${command} -R $EXT_DIR`;
 
@@ -144,117 +95,6 @@ export class MinitestTests extends Tests {
   }
 
   /**
-   * Convert a string from snake_case to PascalCase.
-   * Note that the function will return the input string unchanged if it
-   * includes a '/'.
-   *
-   * @param string The string to convert to PascalCase.
-   * @return The converted string.
-   */
-  protected snakeToPascalCase(string: string): string {
-    if (string.includes('/')) { return string }
-    return string.split("_").map(substr => substr.charAt(0).toUpperCase() + substr.slice(1)).join("");
-  }
-
-  /**
-   * Sorts an array of TestSuiteInfo objects by label.
-   *
-   * @param testSuiteChildren An array of TestSuiteInfo objects, generally the children of another TestSuiteInfo object.
-   * @return The input array, sorted by label.
-   */
-  protected sortTestSuiteChildren(testSuiteChildren: Array<TestSuiteInfo>): Array<TestSuiteInfo> {
-    testSuiteChildren = testSuiteChildren.sort((a: TestSuiteInfo, b: TestSuiteInfo) => {
-      let comparison = 0;
-      if (a.label > b.label) {
-        comparison = 1;
-      } else if (a.label < b.label) {
-        comparison = -1;
-      }
-      return comparison;
-    });
-
-    return testSuiteChildren;
-  }
-
-  /**
-   * Create the base test suite with a root node and one layer of child nodes
-   * representing the subdirectories of spec/, and then any files under the
-   * given subdirectory.
-   *
-   * @param tests Test objects returned by our custom RSpec formatter.
-   * @return The test suite root with its children.
-   */
-  public async getBaseTestSuite(
-    tests: any[]
-  ): Promise<TestSuiteInfo> {
-    let rootTestSuite: TestSuiteInfo = {
-      type: 'suite',
-      id: 'root',
-      label: 'RSpec',
-      children: []
-    };
-
-    // Create an array of all test files and then abuse Sets to make it unique.
-    let uniqueFiles = [...new Set(tests.map((test: { file_path: string; }) => test.file_path))];
-
-    let splitFilesArray: Array<string[]> = [];
-
-    // Remove the spec/ directory from all the file path.
-    uniqueFiles.forEach((file) => {
-      splitFilesArray.push(file.replace(`${this.getTestDirectory()}`, "").split('/'));
-    });
-
-    // This gets the main types of tests, e.g. features, helpers, models, requests, etc.
-    let subdirectories: Array<string> = [];
-    splitFilesArray.forEach((splitFile) => {
-      if (splitFile.length > 1) {
-        subdirectories.push(splitFile[0]);
-      }
-    });
-    subdirectories = [...new Set(subdirectories)];
-
-    // A nested loop to iterate through the direct subdirectories of spec/ and then
-    // organize the files under those subdirectories.
-    subdirectories.forEach((directory) => {
-      let filesInDirectory: Array<TestSuiteInfo> = [];
-
-      let uniqueFilesInDirectory: Array<string> = uniqueFiles.filter((file) => {
-        return file.startsWith(`${this.getTestDirectory()}${directory}/`);
-      });
-
-      // Get the sets of tests for each file in the current directory.
-      uniqueFilesInDirectory.forEach((currentFile: string) => {
-        let currentFileTestSuite = this.getTestSuiteForFile({ tests, currentFile, directory });
-        filesInDirectory.push(currentFileTestSuite);
-      });
-
-      let directoryTestSuite: TestSuiteInfo = {
-        type: 'suite',
-        id: directory,
-        label: directory,
-        children: filesInDirectory
-      };
-
-      rootTestSuite.children.push(directoryTestSuite);
-    });
-
-    // Sort test suite types alphabetically.
-    rootTestSuite.children = this.sortTestSuiteChildren(rootTestSuite.children as Array<TestSuiteInfo>);
-
-    // Get files that are direct descendants of the spec/ directory.
-    let topDirectoryFiles = uniqueFiles.filter((filePath) => {
-      return filePath.replace(`${this.getTestDirectory()}`, "").split('/').length === 1;
-    });
-
-    topDirectoryFiles.forEach((currentFile) => {
-      let currentFileTestSuite = super.getTestSuiteForFile({ tests, currentFile });
-      rootTestSuite.children.push(currentFileTestSuite);
-    });
-
-    return rootTestSuite;
-  }
-
-  /**
    * Runs a single test.
    *
    * @param testLocation A file path with a line number, e.g. `/path/to/spec.rb:12`.
@@ -270,7 +110,7 @@ export class MinitestTests extends Tests {
       env: this.getProcessEnv()
     };
 
-    let testCommand = `${this.getRspecCommand()} vscode:minitest:run ${relativeLocation}:${line}`;
+    let testCommand = `${this.getTestCommand()} vscode:minitest:run ${relativeLocation}:${line}`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -297,7 +137,7 @@ export class MinitestTests extends Tests {
     };
 
     // Run tests for a given file at once with a single command.
-    let testCommand = `${this.getRspecCommand()} vscode:minitest:run ${relativeFile}`;
+    let testCommand = `${this.getTestCommand()} vscode:minitest:run ${relativeFile}`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -321,7 +161,7 @@ export class MinitestTests extends Tests {
       env: this.getProcessEnv()
     };
 
-    let testCommand = `${this.getRspecCommand()} vscode:minitest:run`;
+    let testCommand = `${this.getTestCommand()} vscode:minitest:run`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -58,7 +58,7 @@ export class MinitestTests extends Tests {
    * @return The Minitest command
    */
   protected getTestCommand(): string {
-    let command: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('rakeCommand') as string) || 'bundle exec rake';
+    let command: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('minitestCommand') as string) || 'bundle exec rake';
     return `${command} -R $EXT_DIR`;
 
   }

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -4,6 +4,8 @@ import * as childProcess from 'child_process';
 import { Tests } from './tests';
 
 export class MinitestTests extends Tests {
+  testFrameworkName = 'Minitest';
+
   /**
    * Representation of the Minitest test suite as a TestSuiteInfo object.
    *

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -1,0 +1,630 @@
+import * as vscode from 'vscode';
+import { TestSuiteInfo, TestInfo, TestRunStartedEvent, TestRunFinishedEvent, TestSuiteEvent, TestEvent } from 'vscode-test-adapter-api';
+import * as childProcess from 'child_process';
+import * as split2 from 'split2';
+import { Log } from 'vscode-test-adapter-util';
+
+export class RspecTests {
+  private context: vscode.ExtensionContext;
+  private testStatesEmitter: vscode.EventEmitter<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent>;
+  private currentChildProcess: childProcess.ChildProcess | undefined;
+  private log: Log;
+  private testSuite: TestSuiteInfo | undefined;
+
+  /**
+   * @param context Extension context provided by vscode.
+   * @param testStatesEmitter An emitter for the test suite's state.
+   * @param log The Test Adapter logger, for logging.
+   */
+  constructor(
+    context: vscode.ExtensionContext,
+    testStatesEmitter: vscode.EventEmitter<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent>,
+    log: Log
+  ) {
+    this.context = context;
+    this.testStatesEmitter = testStatesEmitter;
+    this.log = log;
+  }
+
+  /**
+   * Representation of the RSpec test suite as a TestSuiteInfo object.
+   *
+   * @return The RSpec test suite as a TestSuiteInfo object.
+   */
+  rspecTests = async () => new Promise<TestSuiteInfo>((resolve, reject) => {
+    try {
+      // If test suite already exists, use testSuite. Otherwise, load them.
+      let rspecTests = this.testSuite ? this.testSuite : this.loadRspecTests();
+      return resolve(rspecTests);
+    } catch (err) {
+      this.log.error(`Error while attempting to load RSpec tests: ${err.message}`);
+      return reject(err);
+    }
+  });
+
+  /**
+   * Perform a dry-run of the test suite to get information about every test.
+   *
+   * @return The raw output from the RSpec JSON formatter.
+   */
+  initRspecTests = async () => new Promise<string>((resolve, reject) => {
+    let cmd = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter --order defined --dry-run`;
+
+    this.log.info(`Running dry-run of RSpec test suite with the following command: ${cmd}`);
+
+    // Allow a buffer of 64MB.
+    const execArgs: childProcess.ExecOptions = {
+      cwd: vscode.workspace.rootPath,
+      maxBuffer: 8192 * 8192
+    };
+
+    childProcess.exec(cmd, execArgs, (err, stdout) => {
+      if (err) {
+        this.log.error(`Error while finding RSpec test suite: ${err.message}`);
+        // Show an error message.
+        vscode.window.showWarningMessage("Ruby Test Explorer failed to find an RSpec test suite. Make sure RSpec is installed and your configured RSpec command is correct.");
+        vscode.window.showErrorMessage(err.message);
+        throw err;
+      }
+      resolve(stdout);
+    });
+  });
+
+  /**
+   * Takes the output from initRSpecTests() and parses the resulting
+   * JSON into a TestSuiteInfo object.
+   *
+   * @return The full RSpec test suite.
+   */
+  public async loadRspecTests(): Promise<TestSuiteInfo> {
+    let output = await this.initRspecTests();
+    this.log.debug('Passing raw output from dry-run into getJsonFromRspecOutput.');
+    this.log.debug(`${output}`);
+    output = this.getJsonFromRspecOutput(output);
+    this.log.debug('Parsing the below JSON:');
+    this.log.debug(`${output}`);
+    let rspecMetadata = JSON.parse(output);
+
+    let tests: Array<{ id: string; full_description: string; description: string; file_path: string; line_number: number; location: number; }> = [];
+
+    rspecMetadata.examples.forEach((test: { id: string; full_description: string; description: string; file_path: string; line_number: number; location: number; }) => {
+      let test_location_array: Array<string> = test.id.substring(test.id.indexOf("[") + 1, test.id.lastIndexOf("]")).split(':');
+      let test_location_string: string = test_location_array.join('');
+      test.location = parseInt(test_location_string);
+
+      tests.push(test);
+    });
+
+    let testSuite: TestSuiteInfo = await this.getBaseTestSuite(tests);
+
+    // Sort the children of each test suite based on their location in the test tree.
+    (testSuite.children as Array<TestSuiteInfo>).forEach((suite: TestSuiteInfo) => {
+      // NOTE: This will only sort correctly if everything is nested at the same
+      // level, e.g. 111, 112, 121, etc. Once a fourth level of indentation is
+      // introduced, the location is generated as e.g. 1231, which won't
+      // sort properly relative to everything else.
+      (suite.children as Array<TestInfo>).sort((a: TestInfo, b: TestInfo) => {
+        if ((a as TestInfo).type === "test" && (b as TestInfo).type === "test") {
+          let aLocation: number = this.getTestLocation(a as TestInfo);
+          let bLocation: number = this.getTestLocation(b as TestInfo);
+          return aLocation - bLocation;
+        } else {
+          return 0;
+        }
+      })
+    });
+
+    this.testSuite = testSuite;
+
+    return Promise.resolve<TestSuiteInfo>(testSuite);
+  }
+
+  /**
+   * Kills the current child process if one exists.
+   */
+  public killChild(): void {
+    if (this.currentChildProcess) {
+      this.currentChildProcess.kill();
+      this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
+    }
+  }
+
+  /**
+   * Pull JSON out of the RSpec output.
+   *
+   * RSpec frequently returns bad data even when it's told to format the output
+   * as JSON, e.g. due to code coverage messages and other injections from gems.
+   * This gets the JSON by searching for `START_OF_RSPEC_JSON` and an opening
+   * curly brace, as well as a closing curly brace and `END_OF_RSPEC_JSON`.
+   * These are output by the custom RSpec formatter as part of the final
+   * JSON output.
+   *
+   * @param output The output returned by running an RSpec command
+   * @return A string representation of the JSON found in the RSpec output.
+   */
+  private getJsonFromRspecOutput(output: string): string {
+    output = output.substring(output.indexOf("START_OF_RSPEC_JSON{"), output.lastIndexOf("}END_OF_RSPEC_JSON") + 1);
+    // Get rid of the `START_OF_RSPEC_JSON` and `END_OF_RSPEC_JSON` to verify that the JSON is valid.
+    return output.substring(output.indexOf("{"), output.lastIndexOf("}") + 1);
+  }
+
+  /**
+   * Get the location of the test in the testing tree.
+   *
+   * Test ids are in the form of `/spec/model/game_spec.rb[1:1:1]`, and this
+   * function turns that into `111`. The number is used to order the tests
+   * in the explorer.
+   *
+   * @param test The test we want to get the location of.
+   * @return A number representing the location of the test in the test tree.
+   */
+  private getTestLocation(test: TestInfo): number {
+    return parseInt(test.id.substring(test.id.indexOf("[") + 1, test.id.lastIndexOf("]")).split(':').join(''));
+  }
+
+  /**
+   * Get the user-configured RSpec command, if there is one.
+   *
+   * @return The RSpec command
+   */
+  private getRspecCommand(): string {
+    let command: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('rspecCommand') as string);
+    return command || 'bundle exec rspec';
+  }
+
+  /**
+   * Get the user-configured spec directory, if there is one.
+   *
+   * @return The spec directory
+   */
+  private getSpecDirectory(): string {
+    let directory: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('specDirectory') as string);
+    return directory || './spec/';
+  }
+
+  /**
+   * Get the absolute path of the custom_formatter.rb file.
+   *
+   * @return The spec directory
+   */
+  private getCustomFormatterLocation(): string {
+    return this.context.asAbsolutePath('./custom_formatter.rb');
+  }
+
+  /**
+   * Convert a string from snake_case to PascalCase.
+   * Note that the function will return the input string unchanged if it
+   * includes a '/'.
+   *
+   * @param string The string to convert to PascalCase.
+   * @return The converted string.
+   */
+  private snakeToPascalCase(string: string): string {
+    if (string.includes('/')) { return string }
+    return string.split("_").map(substr => substr.charAt(0).toUpperCase() + substr.slice(1)).join("");
+  }
+
+  /**
+   * Sorts an array of TestSuiteInfo objects by label.
+   *
+   * @param testSuiteChildren An array of TestSuiteInfo objects, generally the children of another TestSuiteInfo object.
+   * @return The input array, sorted by label.
+   */
+  private sortTestSuiteChildren(testSuiteChildren: Array<TestSuiteInfo>): Array<TestSuiteInfo> {
+    testSuiteChildren = testSuiteChildren.sort((a: TestSuiteInfo, b: TestSuiteInfo) => {
+      let comparison = 0;
+      if (a.label > b.label) {
+        comparison = 1;
+      } else if (a.label < b.label) {
+        comparison = -1;
+      }
+      return comparison;
+    });
+
+    return testSuiteChildren;
+  }
+
+  /**
+   * Get the tests in a given file.
+   */
+  public getTestSuiteForFile(
+    { tests, currentFile, directory }: {
+      tests: Array<{
+        id: string;
+        full_description: string;
+        description: string;
+        file_path: string;
+        line_number: number;
+        location: number;
+      }>; currentFile: string; directory?: string;
+    }): TestSuiteInfo {
+    let currentFileTests = tests.filter(test => {
+      return test.file_path === currentFile
+    });
+
+    let currentFileTestsInfo = currentFileTests as unknown as Array<TestInfo>;
+    currentFileTestsInfo.forEach((test: TestInfo) => {
+      test.type = 'test';
+      test.label = '';
+    });
+
+    let currentFileLabel = '';
+
+    if (directory) {
+      currentFileLabel = currentFile.replace(`${this.getSpecDirectory()}${directory}/`, '');
+    } else {
+      currentFileLabel = currentFile.replace(`${this.getSpecDirectory()}`, '');
+    }
+
+    let pascalCurrentFileLabel = this.snakeToPascalCase(currentFileLabel.replace('_spec.rb', ''));
+
+    let currentFileTestInfoArray: Array<TestInfo> = currentFileTests.map((test) => {
+      // Concatenation of "/Users/username/whatever/project_dir" and "./spec/path/here.rb",
+      // but with the latter's first character stripped.
+      let filePath: string = `${vscode.workspace.rootPath}${test.file_path.substr(1)}`;
+
+      // RSpec provides test ids like "file_name.rb[1:2:3]".
+      // This uses the digits at the end of the id to create
+      // an array of numbers representing the location of the
+      // test in the file.
+      let testLocationArray: Array<number> = test.id.substring(test.id.indexOf("[") + 1, test.id.lastIndexOf("]")).split(':').map((x) => {
+        return parseInt(x);
+      });
+
+      // Get the last element in the location array.
+      let testNumber: number = testLocationArray[testLocationArray.length - 1];
+      // If the test doesn't have a name (because it uses the 'it do' syntax), "test #n"
+      // is appended to the test description to distinguish between separate tests.
+      let description: string = test.description.startsWith('example at ') ? `${test.full_description}test #${testNumber}` : test.full_description;
+
+      // If the current file label doesn't have a slash in it and it starts with the PascalCase'd
+      // file name, remove the from the start of the description. This turns, e.g.
+      // `ExternalAccount Validations blah blah blah' into 'Validations blah blah blah'.
+      if (!pascalCurrentFileLabel.includes('/') && description.startsWith(pascalCurrentFileLabel)) {
+        // Optional check for a space following the PascalCase file name. In some
+        // cases, e.g. 'FileName#method_name` there's no space after the file name.
+        let regexString = `${pascalCurrentFileLabel}[ ]?`;
+        let regex = new RegExp(regexString, "g");
+        description = description.replace(regex, '');
+      }
+
+      let testInfo: TestInfo = {
+        type: 'test',
+        id: test.id,
+        label: description,
+        file: filePath,
+        // Line numbers are 0-indexed
+        line: test.line_number - 1
+      }
+
+      return testInfo;
+    });
+
+    let currentFileTestSuite: TestSuiteInfo = {
+      type: 'suite',
+      id: currentFile,
+      label: currentFileLabel,
+      file: currentFile,
+      children: currentFileTestInfoArray
+    }
+
+    return currentFileTestSuite;
+  }
+
+  /**
+   * Create the base test suite with a root node and one layer of child nodes
+   * representing the subdirectories of spec/, and then any files under the
+   * given subdirectory.
+   *
+   * @param tests Test objects returned by our custom RSpec formatter.
+   * @return The test suite root with its children.
+   */
+  public async getBaseTestSuite(
+    tests: any[]
+  ): Promise<TestSuiteInfo> {
+    let rootTestSuite: TestSuiteInfo = {
+      type: 'suite',
+      id: 'root',
+      label: 'RSpec',
+      children: []
+    };
+
+    // Create an array of all test files and then abuse Sets to make it unique.
+    let uniqueFiles = [...new Set(tests.map((test: { file_path: string; }) => test.file_path))];
+
+    let splitFilesArray: Array<string[]> = [];
+
+    // Remove the spec/ directory from all the file path.
+    uniqueFiles.forEach((file) => {
+      splitFilesArray.push(file.replace(`${this.getSpecDirectory()}`, "").split('/'));
+    });
+
+    // This gets the main types of tests, e.g. features, helpers, models, requests, etc.
+    let subdirectories: Array<string> = [];
+    splitFilesArray.forEach((splitFile) => {
+      if (splitFile.length > 1) {
+        subdirectories.push(splitFile[0]);
+      }
+    });
+    subdirectories = [...new Set(subdirectories)];
+
+    // A nested loop to iterate through the direct subdirectories of spec/ and then
+    // organize the files under those subdirectories.
+    subdirectories.forEach((directory) => {
+      let filesInDirectory: Array<TestSuiteInfo> = [];
+
+      let uniqueFilesInDirectory: Array<string> = uniqueFiles.filter((file) => {
+        return file.startsWith(`${this.getSpecDirectory()}${directory}/`);
+      });
+
+      // Get the sets of tests for each file in the current directory.
+      uniqueFilesInDirectory.forEach((currentFile: string) => {
+        let currentFileTestSuite = this.getTestSuiteForFile({ tests, currentFile, directory });
+        filesInDirectory.push(currentFileTestSuite);
+      });
+
+      let directoryTestSuite: TestSuiteInfo = {
+        type: 'suite',
+        id: directory,
+        label: directory,
+        children: filesInDirectory
+      };
+
+      rootTestSuite.children.push(directoryTestSuite);
+    });
+
+    // Sort test suite types alphabetically.
+    rootTestSuite.children = this.sortTestSuiteChildren(rootTestSuite.children as Array<TestSuiteInfo>);
+
+    // Get files that are direct descendants of the spec/ directory.
+    let topDirectoryFiles = uniqueFiles.filter((filePath) => {
+      return filePath.replace(`${this.getSpecDirectory()}`, "").split('/').length === 1;
+    });
+
+    topDirectoryFiles.forEach((currentFile) => {
+      let currentFileTestSuite = this.getTestSuiteForFile({ tests, currentFile });
+      rootTestSuite.children.push(currentFileTestSuite);
+    });
+
+    return rootTestSuite;
+  }
+
+  /**
+   * Assigns the process to currentChildProcess and handles its output and what happens when it exits.
+   *
+   * @param process A process running the tests.
+   * @return A promise that resolves when the test run completes.
+   */
+  handleChildProcess = async (process: childProcess.ChildProcess) => new Promise<string>((resolve, reject) => {
+    this.currentChildProcess = process;
+
+    this.currentChildProcess!.on('exit', () => {
+      this.currentChildProcess = undefined;
+      this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
+      resolve('{}');
+    });
+
+    this.currentChildProcess.stdout!.pipe(split2()).on('data', (data) => {
+      data = data.toString();
+      this.log.debug(`[CHILD PROCESS OUTPUT] ${data}`);
+      if (data.startsWith('PASSED:')) {
+        data = data.replace('PASSED: ', '');
+        this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: data, state: 'passed' });
+      } else if (data.startsWith('FAILED:')) {
+        data = data.replace('FAILED: ', '');
+        this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: data, state: 'failed' });
+      }
+      if (data.includes('START_OF_RSPEC_JSON')) {
+        resolve(data);
+      }
+    });
+  });
+
+  /**
+   * Runs a single test.
+   *
+   * @param testLocation A file path with a line number, e.g. `/path/to/spec.rb:12`.
+   * @return The raw output from running the test.
+   */
+  runSingleTest = async (testLocation: string) => new Promise<string>(async (resolve, reject) => {
+    this.log.info(`Running single test: ${testLocation}`);
+    const spawnArgs: childProcess.SpawnOptions = {
+      cwd: vscode.workspace.rootPath,
+      shell: true
+    };
+
+    let testCommand = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testLocation}`;
+    this.log.info(`Running command: ${testCommand}`);
+
+    let testProcess = childProcess.spawn(
+      testCommand,
+      spawnArgs
+    );
+
+    resolve(await this.handleChildProcess(testProcess));
+  });
+
+  /**
+   * Runs tests in a given file.
+   *
+   * @param testFile The test file's file path, e.g. `/path/to/spec.rb`.
+   * @return The raw output from running the tests.
+   */
+  runTestFile = async (testFile: string) => new Promise<string>(async (resolve, reject) => {
+    this.log.info(`Running test file: ${testFile}`);
+    const spawnArgs: childProcess.SpawnOptions = {
+      cwd: vscode.workspace.rootPath,
+      shell: true
+    };
+
+    // Run tests for a given file at once with a single command.
+    let testCommand = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testFile}`;
+    this.log.info(`Running command: ${testCommand}`);
+
+    let testProcess = childProcess.spawn(
+      testCommand,
+      spawnArgs
+    );
+
+    resolve(await this.handleChildProcess(testProcess));
+  });
+
+  /**
+   * Runs the full test suite for the current workspace.
+   *
+   * @return The raw output from running the test suite.
+   */
+  runFullTestSuite = async () => new Promise<string>(async (resolve, reject) => {
+    this.log.info(`Running full test suite.`);
+    const spawnArgs: childProcess.SpawnOptions = {
+      cwd: vscode.workspace.rootPath,
+      shell: true
+    };
+
+    let testCommand = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter`;
+    this.log.info(`Running command: ${testCommand}`);
+
+    let testProcess = childProcess.spawn(
+      testCommand,
+      spawnArgs
+    );
+
+    resolve(await this.handleChildProcess(testProcess));
+  });
+
+  /**
+   * Runs the test suite by iterating through each test and running it.
+   *
+   * @param tests
+   */
+  runRspecTests = async (
+    tests: string[]
+  ): Promise<void> => {
+    let testSuite: TestSuiteInfo = await this.rspecTests();
+
+    for (const suiteOrTestId of tests) {
+      const node = this.findNode(testSuite, suiteOrTestId);
+      if (node) {
+        await this.runNode(node);
+      }
+    }
+  }
+
+  /**
+   * Recursively search for a node in the test suite list.
+   *
+   * @param searchNode The test or test suite to search in.
+   * @param id The id of the test or test suite.
+   */
+  private findNode(searchNode: TestSuiteInfo | TestInfo, id: string): TestSuiteInfo | TestInfo | undefined {
+    if (searchNode.id === id) {
+      return searchNode;
+    } else if (searchNode.type === 'suite') {
+      for (const child of searchNode.children) {
+        const found = this.findNode(child, id);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Recursively run a node or its children.
+   *
+   * @param node A test or test suite.
+   */
+  private async runNode(node: TestSuiteInfo | TestInfo): Promise<void> {
+    // Special case handling for the root suite, since it can be run
+    // with runFullTestSuite()
+    if (node.type === 'suite' && node.id === 'root') {
+      this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: node.id, state: 'running' });
+
+      let testOutput = await this.runFullTestSuite();
+      testOutput = this.getJsonFromRspecOutput(testOutput);
+      let testMetadata = JSON.parse(testOutput);
+      let tests: Array<any> = testMetadata.examples;
+
+      if (tests && tests.length > 0) {
+        tests.forEach((test: { id: string | TestInfo; }) => {
+          this.handleStatus(test);
+        });
+      }
+
+      this.testStatesEmitter.fire(<TestSuiteEvent>{ type: 'suite', suite: node.id, state: 'completed' });
+      // If the suite is a file, run the tests as a file rather than as separate tests.
+    } else if (node.type === 'suite' && node.label.endsWith('.rb')) {
+      this.testStatesEmitter.fire(<TestSuiteEvent>{ type: 'suite', suite: node.id, state: 'running' });
+
+      let testOutput = await this.runTestFile(`${node.file}`);
+
+      testOutput = this.getJsonFromRspecOutput(testOutput);
+      let testMetadata = JSON.parse(testOutput);
+      let tests: Array<any> = testMetadata.examples;
+
+      if (tests && tests.length > 0) {
+        tests.forEach((test: { id: string | TestInfo; }) => {
+          this.handleStatus(test);
+        });
+      }
+
+      this.testStatesEmitter.fire(<TestSuiteEvent>{ type: 'suite', suite: node.id, state: 'completed' });
+
+    } else if (node.type === 'suite') {
+
+      this.testStatesEmitter.fire(<TestSuiteEvent>{ type: 'suite', suite: node.id, state: 'running' });
+
+      for (const child of node.children) {
+        await this.runNode(child);
+      }
+
+      this.testStatesEmitter.fire(<TestSuiteEvent>{ type: 'suite', suite: node.id, state: 'completed' });
+
+    } else if (node.type === 'test') {
+      if (node.file !== undefined && node.line !== undefined) {
+        this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: node.id, state: 'running' });
+
+        // Run the test at the given line, add one since the line is 0-indexed in
+        // VS Code and 1-indexed for RSpec.
+        let testOutput = await this.runSingleTest(`${node.file}:${node.line + 1}`);
+
+        testOutput = this.getJsonFromRspecOutput(testOutput);
+        let testMetadata = JSON.parse(testOutput);
+        let currentTest = testMetadata.examples[0];
+
+        this.handleStatus(currentTest);
+      }
+    }
+  }
+
+  /**
+   * Handles test state based on the output returned by the custom RSpec formatter.
+   *
+   * @param test The test that we want to handle.
+   */
+  private handleStatus(test: any): void {
+    this.log.debug(`Handling status of test: ${JSON.stringify(test)}`);
+    if (test.status === "passed") {
+      this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: test.id, state: 'passed' });
+    } else if (test.status === "failed" && test.pending_message === null) {
+      let errorMessage: string = test.exception.message;
+
+      // Add backtrace to errorMessage if it exists.
+      if (test.exception.backtrace) {
+        errorMessage += `\n\nBacktrace:\n`;
+        test.exception.backtrace.forEach((line: string) => {
+          errorMessage += `${line}\n`;
+        });
+      }
+
+      this.testStatesEmitter.fire(<TestEvent>{
+        type: 'test',
+        test: test.id,
+        state: 'failed',
+        message: errorMessage
+      });
+    } else if (test.status === "failed" && test.pending_message !== null) {
+      // Handle pending test cases.
+      this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: test.id, state: 'skipped', message: test.pending_message });
+    }
+  };
+}

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -499,7 +499,7 @@ export class MinitestTests extends RspecTests {
    *
    * @param tests
    */
-  runRspecTests = async (
+  runTests = async (
     tests: string[]
   ): Promise<void> => {
     let testSuite: TestSuiteInfo = await this.rspecTests();

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -612,9 +612,12 @@ export class MinitestTests extends RspecTests {
       let errorMessageLine: number = test.line_number;
       let errorMessage: string = test.exception.message;
 
+      if (test.exception.position) {
+        errorMessageLine = test.exception.position;
+      }
+
       // Add backtrace to errorMessage if it exists.
       if (test.exception.backtrace) {
-        errorMessageLine = parseInt(test.exception.backtrace[0].split(":")[1]);
         errorMessage += `\n\nBacktrace:\n`;
         test.exception.backtrace.forEach((line: string) => {
           errorMessage += `${line}\n`;

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
-import { TestSuiteInfo, TestInfo, TestRunFinishedEvent, TestEvent } from 'vscode-test-adapter-api';
+import { TestSuiteInfo, TestInfo, TestEvent } from 'vscode-test-adapter-api';
 import * as childProcess from 'child_process';
-import * as split2 from 'split2';
 import { Tests } from './tests';
 
 export class MinitestTests extends Tests {
@@ -101,16 +100,6 @@ export class MinitestTests extends Tests {
   }
 
   /**
-   * Kills the current child process if one exists.
-   */
-  public killChild(): void {
-    if (this.currentChildProcess) {
-      this.currentChildProcess.kill();
-      this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
-    }
-  }
-
-  /**
    * Get the user-configured RSpec command, if there is one.
    *
    * @return The RSpec command
@@ -122,11 +111,11 @@ export class MinitestTests extends Tests {
   }
 
   /**
-   * Get the user-configured spec directory, if there is one.
+   * Get the user-configured test directory, if there is one.
    *
-   * @return The spec directory
+   * @return The test directory
    */
-  protected getSpecDirectory(): string {
+  getTestDirectory(): string {
     let directory: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('minitestDirectory') as string);
     return directory || './test/';
   }
@@ -150,7 +139,7 @@ export class MinitestTests extends Tests {
     return Object.assign({}, process.env, {
       "RAILS_ENV": "test",
       "EXT_DIR": this.getRubyScriptsLocation(),
-      "TESTS_DIR": this.getSpecDirectory()
+      "TESTS_DIR": this.getTestDirectory()
     });
   }
 
@@ -188,93 +177,6 @@ export class MinitestTests extends Tests {
   }
 
   /**
-   * Get the tests in a given file.
-   */
-  public getTestSuiteForFile(
-    { tests, currentFile, directory }: {
-      tests: Array<{
-        id: string;
-        full_description: string;
-        description: string;
-        file_path: string;
-        line_number: number;
-        location: number;
-      }>; currentFile: string; directory?: string;
-    }): TestSuiteInfo {
-    let currentFileTests = tests.filter(test => {
-      return test.file_path === currentFile
-    });
-
-    let currentFileTestsInfo = currentFileTests as unknown as Array<TestInfo>;
-    currentFileTestsInfo.forEach((test: TestInfo) => {
-      test.type = 'test';
-      test.label = '';
-    });
-
-    let currentFileLabel = '';
-
-    if (directory) {
-      currentFileLabel = currentFile.replace(`${this.getSpecDirectory()}${directory}/`, '');
-    } else {
-      currentFileLabel = currentFile.replace(`${this.getSpecDirectory()}`, '');
-    }
-
-    let pascalCurrentFileLabel = this.snakeToPascalCase(currentFileLabel.replace('_spec.rb', ''));
-
-    let currentFileTestInfoArray: Array<TestInfo> = currentFileTests.map((test) => {
-      // Concatenation of "/Users/username/whatever/project_dir" and "./spec/path/here.rb",
-      // but with the latter's first character stripped.
-      let filePath: string = `${vscode.workspace.rootPath}${test.file_path.substr(1)}`;
-
-      // RSpec provides test ids like "file_name.rb[1:2:3]".
-      // This uses the digits at the end of the id to create
-      // an array of numbers representing the location of the
-      // test in the file.
-      let testLocationArray: Array<number> = test.id.substring(test.id.indexOf("[") + 1, test.id.lastIndexOf("]")).split(':').map((x) => {
-        return parseInt(x);
-      });
-
-      // Get the last element in the location array.
-      let testNumber: number = testLocationArray[testLocationArray.length - 1];
-      // If the test doesn't have a name (because it uses the 'it do' syntax), "test #n"
-      // is appended to the test description to distinguish between separate tests.
-      let description: string = test.description.startsWith('example at ') ? `${test.full_description}test #${testNumber}` : test.full_description;
-
-      // If the current file label doesn't have a slash in it and it starts with the PascalCase'd
-      // file name, remove the from the start of the description. This turns, e.g.
-      // `ExternalAccount Validations blah blah blah' into 'Validations blah blah blah'.
-      if (!pascalCurrentFileLabel.includes('/') && description.startsWith(pascalCurrentFileLabel)) {
-        // Optional check for a space following the PascalCase file name. In some
-        // cases, e.g. 'FileName#method_name` there's no space after the file name.
-        let regexString = `${pascalCurrentFileLabel}[ ]?`;
-        let regex = new RegExp(regexString, "g");
-        description = description.replace(regex, '');
-      }
-
-      let testInfo: TestInfo = {
-        type: 'test',
-        id: test.id,
-        label: description,
-        file: filePath,
-        // Line numbers are 0-indexed
-        line: test.line_number - 1
-      }
-
-      return testInfo;
-    });
-
-    let currentFileTestSuite: TestSuiteInfo = {
-      type: 'suite',
-      id: currentFile,
-      label: currentFileLabel,
-      file: currentFile,
-      children: currentFileTestInfoArray
-    }
-
-    return currentFileTestSuite;
-  }
-
-  /**
    * Create the base test suite with a root node and one layer of child nodes
    * representing the subdirectories of spec/, and then any files under the
    * given subdirectory.
@@ -299,7 +201,7 @@ export class MinitestTests extends Tests {
 
     // Remove the spec/ directory from all the file path.
     uniqueFiles.forEach((file) => {
-      splitFilesArray.push(file.replace(`${this.getSpecDirectory()}`, "").split('/'));
+      splitFilesArray.push(file.replace(`${this.getTestDirectory()}`, "").split('/'));
     });
 
     // This gets the main types of tests, e.g. features, helpers, models, requests, etc.
@@ -317,7 +219,7 @@ export class MinitestTests extends Tests {
       let filesInDirectory: Array<TestSuiteInfo> = [];
 
       let uniqueFilesInDirectory: Array<string> = uniqueFiles.filter((file) => {
-        return file.startsWith(`${this.getSpecDirectory()}${directory}/`);
+        return file.startsWith(`${this.getTestDirectory()}${directory}/`);
       });
 
       // Get the sets of tests for each file in the current directory.
@@ -341,47 +243,16 @@ export class MinitestTests extends Tests {
 
     // Get files that are direct descendants of the spec/ directory.
     let topDirectoryFiles = uniqueFiles.filter((filePath) => {
-      return filePath.replace(`${this.getSpecDirectory()}`, "").split('/').length === 1;
+      return filePath.replace(`${this.getTestDirectory()}`, "").split('/').length === 1;
     });
 
     topDirectoryFiles.forEach((currentFile) => {
-      let currentFileTestSuite = this.getTestSuiteForFile({ tests, currentFile });
+      let currentFileTestSuite = super.getTestSuiteForFile({ tests, currentFile });
       rootTestSuite.children.push(currentFileTestSuite);
     });
 
     return rootTestSuite;
   }
-
-  /**
-   * Assigns the process to currentChildProcess and handles its output and what happens when it exits.
-   *
-   * @param process A process running the tests.
-   * @return A promise that resolves when the test run completes.
-   */
-  handleChildProcess = async (process: childProcess.ChildProcess) => new Promise<string>((resolve, reject) => {
-    this.currentChildProcess = process;
-
-    this.currentChildProcess!.on('exit', () => {
-      this.currentChildProcess = undefined;
-      this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
-      resolve('{}');
-    });
-
-    this.currentChildProcess.stdout!.pipe(split2()).on('data', (data) => {
-      data = data.toString();
-      this.log.debug(`[CHILD PROCESS OUTPUT] ${data}`);
-      if (data.startsWith('PASSED:')) {
-        data = data.replace('PASSED: ', '');
-        this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: data, state: 'passed' });
-      } else if (data.startsWith('FAILED:')) {
-        data = data.replace('FAILED: ', '');
-        this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: data, state: 'failed' });
-      }
-      if (data.includes('START_OF_MINITEST_JSON')) {
-        resolve(data);
-      }
-    });
-  });
 
   /**
    * Runs a single test.

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -4,6 +4,7 @@ import * as childProcess from 'child_process';
 import { Tests } from './tests';
 
 export class RspecTests extends Tests {
+  testFrameworkName = 'RSpec';
 
   /**
    * Representation of the RSpec test suite as a TestSuiteInfo object.

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { TestSuiteInfo, TestInfo, TestEvent } from 'vscode-test-adapter-api';
+import { TestSuiteInfo, TestEvent } from 'vscode-test-adapter-api';
 import * as childProcess from 'child_process';
 import { Tests } from './tests';
 
@@ -26,8 +26,8 @@ export class RspecTests extends Tests {
    *
    * @return The raw output from the RSpec JSON formatter.
    */
-  initRspecTests = async () => new Promise<string>((resolve, reject) => {
-    let cmd = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter --order defined --dry-run`;
+  initTests = async () => new Promise<string>((resolve, reject) => {
+    let cmd = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter --order defined --dry-run`;
 
     this.log.info(`Running dry-run of RSpec test suite with the following command: ${cmd}`);
 
@@ -50,60 +50,11 @@ export class RspecTests extends Tests {
   });
 
   /**
-   * Takes the output from initRSpecTests() and parses the resulting
-   * JSON into a TestSuiteInfo object.
-   *
-   * @return The full RSpec test suite.
-   */
-  public async loadTests(): Promise<TestSuiteInfo> {
-    let output = await this.initRspecTests();
-    this.log.debug('Passing raw output from dry-run into getJsonFromRspecOutput.');
-    this.log.debug(`${output}`);
-    output = this.getJsonFromOutput(output);
-    this.log.debug('Parsing the below JSON:');
-    this.log.debug(`${output}`);
-    let rspecMetadata = JSON.parse(output);
-
-    let tests: Array<{ id: string; full_description: string; description: string; file_path: string; line_number: number; location: number; }> = [];
-
-    rspecMetadata.examples.forEach((test: { id: string; full_description: string; description: string; file_path: string; line_number: number; location: number; }) => {
-      let test_location_array: Array<string> = test.id.substring(test.id.indexOf("[") + 1, test.id.lastIndexOf("]")).split(':');
-      let test_location_string: string = test_location_array.join('');
-      test.location = parseInt(test_location_string);
-
-      tests.push(test);
-    });
-
-    let testSuite: TestSuiteInfo = await this.getBaseTestSuite(tests);
-
-    // Sort the children of each test suite based on their location in the test tree.
-    (testSuite.children as Array<TestSuiteInfo>).forEach((suite: TestSuiteInfo) => {
-      // NOTE: This will only sort correctly if everything is nested at the same
-      // level, e.g. 111, 112, 121, etc. Once a fourth level of indentation is
-      // introduced, the location is generated as e.g. 1231, which won't
-      // sort properly relative to everything else.
-      (suite.children as Array<TestInfo>).sort((a: TestInfo, b: TestInfo) => {
-        if ((a as TestInfo).type === "test" && (b as TestInfo).type === "test") {
-          let aLocation: number = super.getTestLocation(a as TestInfo);
-          let bLocation: number = super.getTestLocation(b as TestInfo);
-          return aLocation - bLocation;
-        } else {
-          return 0;
-        }
-      })
-    });
-
-    this.testSuite = testSuite;
-
-    return Promise.resolve<TestSuiteInfo>(testSuite);
-  }
-
-  /**
    * Get the user-configured RSpec command, if there is one.
    *
    * @return The RSpec command
    */
-  protected getRspecCommand(): string {
+  protected getTestCommand(): string {
     let command: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('rspecCommand') as string);
     return command || 'bundle exec rspec';
   }
@@ -128,117 +79,6 @@ export class RspecTests extends Tests {
   }
 
   /**
-   * Convert a string from snake_case to PascalCase.
-   * Note that the function will return the input string unchanged if it
-   * includes a '/'.
-   *
-   * @param string The string to convert to PascalCase.
-   * @return The converted string.
-   */
-  protected snakeToPascalCase(string: string): string {
-    if (string.includes('/')) { return string }
-    return string.split("_").map(substr => substr.charAt(0).toUpperCase() + substr.slice(1)).join("");
-  }
-
-  /**
-   * Sorts an array of TestSuiteInfo objects by label.
-   *
-   * @param testSuiteChildren An array of TestSuiteInfo objects, generally the children of another TestSuiteInfo object.
-   * @return The input array, sorted by label.
-   */
-  protected sortTestSuiteChildren(testSuiteChildren: Array<TestSuiteInfo>): Array<TestSuiteInfo> {
-    testSuiteChildren = testSuiteChildren.sort((a: TestSuiteInfo, b: TestSuiteInfo) => {
-      let comparison = 0;
-      if (a.label > b.label) {
-        comparison = 1;
-      } else if (a.label < b.label) {
-        comparison = -1;
-      }
-      return comparison;
-    });
-
-    return testSuiteChildren;
-  }
-
-  /**
-   * Create the base test suite with a root node and one layer of child nodes
-   * representing the subdirectories of spec/, and then any files under the
-   * given subdirectory.
-   *
-   * @param tests Test objects returned by our custom RSpec formatter.
-   * @return The test suite root with its children.
-   */
-  public async getBaseTestSuite(
-    tests: any[]
-  ): Promise<TestSuiteInfo> {
-    let rootTestSuite: TestSuiteInfo = {
-      type: 'suite',
-      id: 'root',
-      label: 'RSpec',
-      children: []
-    };
-
-    // Create an array of all test files and then abuse Sets to make it unique.
-    let uniqueFiles = [...new Set(tests.map((test: { file_path: string; }) => test.file_path))];
-
-    let splitFilesArray: Array<string[]> = [];
-
-    // Remove the spec/ directory from all the file path.
-    uniqueFiles.forEach((file) => {
-      splitFilesArray.push(file.replace(`${this.getTestDirectory()}`, "").split('/'));
-    });
-
-    // This gets the main types of tests, e.g. features, helpers, models, requests, etc.
-    let subdirectories: Array<string> = [];
-    splitFilesArray.forEach((splitFile) => {
-      if (splitFile.length > 1) {
-        subdirectories.push(splitFile[0]);
-      }
-    });
-    subdirectories = [...new Set(subdirectories)];
-
-    // A nested loop to iterate through the direct subdirectories of spec/ and then
-    // organize the files under those subdirectories.
-    subdirectories.forEach((directory) => {
-      let filesInDirectory: Array<TestSuiteInfo> = [];
-
-      let uniqueFilesInDirectory: Array<string> = uniqueFiles.filter((file) => {
-        return file.startsWith(`${this.getTestDirectory()}${directory}/`);
-      });
-
-      // Get the sets of tests for each file in the current directory.
-      uniqueFilesInDirectory.forEach((currentFile: string) => {
-        let currentFileTestSuite = super.getTestSuiteForFile({ tests, currentFile, directory });
-        filesInDirectory.push(currentFileTestSuite);
-      });
-
-      let directoryTestSuite: TestSuiteInfo = {
-        type: 'suite',
-        id: directory,
-        label: directory,
-        children: filesInDirectory
-      };
-
-      rootTestSuite.children.push(directoryTestSuite);
-    });
-
-    // Sort test suite types alphabetically.
-    rootTestSuite.children = this.sortTestSuiteChildren(rootTestSuite.children as Array<TestSuiteInfo>);
-
-    // Get files that are direct descendants of the spec/ directory.
-    let topDirectoryFiles = uniqueFiles.filter((filePath) => {
-      return filePath.replace(`${this.getTestDirectory()}`, "").split('/').length === 1;
-    });
-
-    topDirectoryFiles.forEach((currentFile) => {
-      let currentFileTestSuite = super.getTestSuiteForFile({ tests, currentFile });
-      rootTestSuite.children.push(currentFileTestSuite);
-    });
-
-    return rootTestSuite;
-  }
-
-  /**
    * Runs a single test.
    *
    * @param testLocation A file path with a line number, e.g. `/path/to/spec.rb:12`.
@@ -251,7 +91,7 @@ export class RspecTests extends Tests {
       shell: true
     };
 
-    let testCommand = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testLocation}`;
+    let testCommand = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testLocation}`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -276,7 +116,7 @@ export class RspecTests extends Tests {
     };
 
     // Run tests for a given file at once with a single command.
-    let testCommand = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testFile}`;
+    let testCommand = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testFile}`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -299,7 +139,7 @@ export class RspecTests extends Tests {
       shell: true
     };
 
-    let testCommand = `${this.getRspecCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter`;
+    let testCommand = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -497,7 +497,7 @@ export class RspecTests {
    *
    * @param tests
    */
-  runRspecTests = async (
+  runTests = async (
     tests: string[]
   ): Promise<void> => {
     let testSuite: TestSuiteInfo = await this.rspecTests();

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -10,6 +10,7 @@ export abstract class Tests {
   protected currentChildProcess: childProcess.ChildProcess | undefined;
   protected log: Log;
   protected testSuite: TestSuiteInfo | undefined;
+  abstract testFrameworkName: string;
 
   /**
    * @param context Extension context provided by vscode.
@@ -254,7 +255,7 @@ export abstract class Tests {
    * representing the subdirectories of spec/, and then any files under the
    * given subdirectory.
    *
-   * @param tests Test objects returned by our custom RSpec formatter.
+   * @param tests Test objects returned by our custom RSpec formatter or Minitest Rake task.
    * @return The test suite root with its children.
    */
   public async getBaseTestSuite(
@@ -263,7 +264,7 @@ export abstract class Tests {
     let rootTestSuite: TestSuiteInfo = {
       type: 'suite',
       id: 'root',
-      label: 'RSpec',
+      label: this.testFrameworkName,
       children: []
     };
 
@@ -450,7 +451,7 @@ export abstract class Tests {
         this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: node.id, state: 'running' });
 
         // Run the test at the given line, add one since the line is 0-indexed in
-        // VS Code and 1-indexed for RSpec.
+        // VS Code and 1-indexed for RSpec/Minitest.
         let testOutput = await this.runSingleTest(`${node.file}:${node.line + 1}`);
 
         testOutput = this.getJsonFromOutput(testOutput);

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -352,6 +352,12 @@ export abstract class Tests {
       } else if (data.startsWith('FAILED:')) {
         data = data.replace('FAILED: ', '');
         this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: data, state: 'failed' });
+      } else if (data.startsWith('RUNNING:')) {
+        data = data.replace('RUNNING: ', '');
+        this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: data, state: 'running' });
+      } else if (data.startsWith('PENDING:')) {
+        data = data.replace('PENDING: ', '');
+        this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: data, state: 'skipped' });
       }
       if (data.includes('START_OF_TEST_JSON')) {
         resolve(data);


### PR DESCRIPTION
This adds support for minitest. While it's working for me (using it on a rails 4 app and tested it on a rails 5 apps) it's still PoC (naming, tests missing). Minitest support has 2 parts:
- some rake tasks (in the `ruby` folder - `vscode:minitest:list` and `vscode:minitest:run`) which list or run tests - had to do this as there are a lot of differences between the tests runners in different rails versions 
- `minitestTests.ts` file which is copied from rspec and did the minimum changes that to make it work

This also adds an opt-in model for the ruby adapter. The user must add a workspace (or global) config to determine the testing framework used. 

TODOs / Ideas: 
- refactor the JS to have an abstract class which will be extended by minitest / rspec implementations. I'll probably work on that but don't have a lot of time and I'm not fluent in TS / JS
- I would remove some of the heavy lifting from JS (such as building the tree structure) and implement it in ruby
- move rspec list / runner into rake tasks 