### PR TITLE
Remove dependency on ActiveSupport and Rails Autoloading

### DIFF
--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -1,3 +1,4 @@
+require 'minitest'
 require "vscode/minitest/tests"
 require "vscode/minitest/reporter"
 require "vscode/minitest/runner"

--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -21,7 +21,7 @@ module VSCode
     def list(io = $stdout)
       io.sync = true if io.respond_to?(:"sync=")
       data = { version: ::Minitest::VERSION, examples: tests.all }
-      json = ENV.key?("PRETTY") ? JSON.pretty_generate(data.as_json) : JSON.generate(data.as_json)
+      json = ENV.key?("PRETTY") ? JSON.pretty_generate(data) : JSON.generate(data)
       io.puts "START_OF_TEST_JSON#{json}END_OF_TEST_JSON"
     end
 

--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -63,7 +63,7 @@ module VSCode
       end
 
       def vscode_result(r)
-        base = VSCode::Minitest.tests.find_by(klass: r.klass, method: r.name).deep_dup
+        base = VSCode::Minitest.tests.find_by(klass: r.klass, method: r.name).dup
         if r.skipped?
           base[:status] = "failed"
           base[:pending_message] = r.failure.message

--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -95,13 +95,13 @@ module VSCode
 
       def clean_backtrace(backtrace)
         backtrace.map do |line|
-          next unless line.starts_with?(VSCode.project_root.to_s)
+          next unless line.start_with?(VSCode.project_root.to_s)
           line.gsub(VSCode.project_root.to_s + "/", "")
         end.compact
       end
 
       def exception_position(backtrace, file)
-        line = backtrace.find { |frame| frame.starts_with?(file) }
+        line = backtrace.find { |frame| frame.start_with?(file) }
         return unless line
         line.split(":")[1].to_i
       end

--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -39,7 +39,7 @@ module VSCode
         self.failures   = aggregate[::Minitest::Assertion].size
         self.errors     = aggregate[::Minitest::UnexpectedError].size
         self.skips      = aggregate[::Minitest::Skip].size
-        json = ENV.key?("PRETTY") ? JSON.pretty_generate(vscode_data.as_json) : JSON.generate(vscode_data.as_json)
+        json = ENV.key?("PRETTY") ? JSON.pretty_generate(vscode_data) : JSON.generate(vscode_data)
         io.puts "START_OF_TEST_JSON#{json}END_OF_TEST_JSON"
       end
 

--- a/ruby/vscode/minitest/runner.rb
+++ b/ruby/vscode/minitest/runner.rb
@@ -25,18 +25,51 @@ module VSCode
 
       def add_file(file)
         test = VSCode::Minitest.tests.find_by(full_path: file)
-        runnables << [test[:klass].constantize, {}] if test
+        runnables << [constant_for(test[:klass]), {}] if test
       end
 
       def add_file_with_line(file, line)
         test = VSCode::Minitest.tests.find_by(full_path: file, line_number: line)
         raise "There is no test the the given location: #{file}:#{line}" unless test
-        runnables << [test[:klass].constantize, filter: test[:method]]
+        runnables << [constant_for(test[:klass]), filter: test[:method]]
       end
 
       def run
         runnables.each do |runnable, options|
           runnable.run(reporter, options)
+        end
+      end
+
+      private
+
+      def constant_for(str)
+        names = str.split("::".freeze)
+
+        # Trigger a built-in NameError exception including the ill-formed constant in the message.
+        Object.const_get(str) if names.empty?
+
+        # Remove the first blank element in case of '::ClassName' notation.
+        names.shift if names.size > 1 && names.first.empty?
+
+        names.inject(Object) do |constant, name|
+          if constant == Object
+            constant.const_get(name)
+          else
+            candidate = constant.const_get(name)
+            next candidate if constant.const_defined?(name, false)
+            next candidate unless Object.const_defined?(name)
+
+            # Go down the ancestors to check if it is owned directly. The check
+            # stops when we reach Object or the end of ancestors tree.
+            constant = constant.ancestors.inject(constant) do |const, ancestor|
+              break const    if ancestor == Object
+              break ancestor if ancestor.const_defined?(name, false)
+              const
+            end
+
+            # owner is in Object, so raise
+            constant.const_get(name, false)
+          end
         end
       end
     end

--- a/ruby/vscode/minitest/runner.rb
+++ b/ruby/vscode/minitest/runner.rb
@@ -42,6 +42,7 @@ module VSCode
 
       private
 
+      # Taken from https://github.com/rails/rails/blob/fb3ecbf130e141688782bafb7da979bf0ecedf1a/activesupport/lib/active_support/inflector/methods.rb#L271
       def constant_for(str)
         names = str.split("::".freeze)
 


### PR DESCRIPTION
These proposed changes allowed me to run the extension using Minitest with a project that did not include ActiveSupport extensions. In some cases, it seemed that the Active Support method was unnecessary (`as_json`, `starts_with?`), but in some, there are potentially consequences (`Hash#deep_dup`). Using `#dup` worked for my project, but perhaps I'm overlooking something.

The only change that required some potentially heavy lifting was `String#constantize`. I copied the code from [ActiveSupport::Inflector#constantize](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/inflector/methods.rb#L271) and adapted it to a private utility method to avoid monkey patching.


Please let me know your thoughts. Thanks!
