### PR TITLE
added missing require

### DIFF
--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -2,6 +2,7 @@ require 'minitest'
 require "vscode/minitest/tests"
 require "vscode/minitest/reporter"
 require "vscode/minitest/runner"
+require "json"
 
 module Minitest
   # we don't want tests to autorun


### PR DESCRIPTION
Without the require, the following error could be found in the console:

[2019-06-20 12:24:01.397] [ERROR] Error while finding Minitest test suite: Command failed: bundle exec rake -R $EXT_DIR vscode:minitest:list
rake aborted!
NameError: uninitialized constant VSCode::Minitest::JSON