### PR TITLE
Fix missing require and assumption about test names

### DIFF
--- a/ruby/vscode/minitest.rb
+++ b/ruby/vscode/minitest.rb
@@ -3,6 +3,7 @@ require "vscode/minitest/tests"
 require "vscode/minitest/reporter"
 require "vscode/minitest/runner"
 require "json"
+require "pathname"
 
 module Minitest
   # we don't want tests to autorun

--- a/ruby/vscode/minitest/tests.rb
+++ b/ruby/vscode/minitest/tests.rb
@@ -19,7 +19,8 @@ module VSCode
         test_dir = ENV['TESTS_DIR'].gsub('./', '')
         test_dir = test_dir[0...-1] if test_dir.end_with?('/')
         $LOAD_PATH << VSCode.project_root.join(test_dir).to_s
-        Rake::FileList["#{test_dir}/**/*_test.rb"].each { |path| require File.expand_path(path) }
+        file_list = Rake::FileList["#{test_dir}/**/*_test.rb", "#{test_dir}/**/test_*.rb"]
+        file_list.each { |path| require File.expand_path(path) }
       end
 
       def build_list


### PR DESCRIPTION
Rails uses *_test but a lot of gems and libs use test_* as naming convention. Support both.