### PR TITLE
Quote test location argument when running tests

### DIFF
--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -92,7 +92,7 @@ export class RspecTests extends Tests {
       shell: true
     };
 
-    let testCommand = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testLocation}`;
+    let testCommand = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter '${testLocation}'`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -117,7 +117,7 @@ export class RspecTests extends Tests {
     };
 
     // Run tests for a given file at once with a single command.
-    let testCommand = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter ${testFile}`;
+    let testCommand = `${this.getTestCommand()} --require ${this.getCustomFormatterLocation()} --format CustomFormatter '${testFile}'`;
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(


### PR DESCRIPTION
Fixes #41 

It's only a workaround though and will not work for all cases (correctly escaping shell arguments is near to impossible). 

A proper fix would be to not use a shell at all when starting the test process. I created a PoC here: https://github.com/noniq/vscode-ruby-test-adapter/commit/d11dd60b798a8ed0108f4e9e80fac6b1ce026a72 However, as mentioned in the commit message, this is prone to break some of the more exotic setups.