### PR TITLE
Improve how errors are handled when loading RSpec tests.

### DIFF
--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -40,8 +40,6 @@ export class RspecTests extends Tests {
 
     childProcess.exec(cmd, execArgs, (err, stdout) => {
       if (err) {
-        console.log(err);
-        console.log(stdout);
         this.log.error(`Error while finding RSpec test suite: ${err.message}`);
         // Show an error message.
         vscode.window.showWarningMessage(

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -40,10 +40,31 @@ export class RspecTests extends Tests {
 
     childProcess.exec(cmd, execArgs, (err, stdout) => {
       if (err) {
+        console.log(err);
+        console.log(stdout);
         this.log.error(`Error while finding RSpec test suite: ${err.message}`);
         // Show an error message.
-        vscode.window.showWarningMessage("Ruby Test Explorer failed to find an RSpec test suite. Make sure RSpec is installed and your configured RSpec command is correct.");
-        vscode.window.showErrorMessage(err.message);
+        vscode.window.showWarningMessage(
+          "Ruby Test Explorer failed to find an RSpec test suite. Make sure RSpec is installed and your configured RSpec command is correct.",
+          "View error message"
+        ).then(selection => {
+          if (selection === "View error message") {
+            let outputJson = JSON.parse(Tests.getJsonFromOutput(stdout));
+            let outputChannel = vscode.window.createOutputChannel('Ruby Test Explorer Error Message');
+
+            if (outputJson.messages.length > 0) {
+              let outputJsonString = outputJson.messages.join("\n\n");
+              let outputJsonArray = outputJsonString.split("\n");
+              outputJsonArray.forEach((line: string) => {
+                outputChannel.appendLine(line);
+              })
+            } else {
+              outputChannel.append(err.message);
+            }
+            outputChannel.show(false);
+          }
+        });
+
         throw err;
       }
       resolve(stdout);

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -44,7 +44,7 @@ export abstract class Tests {
     let output = await this.initTests();
     this.log.debug('Passing raw output from dry-run into getJsonFromOutput.');
     this.log.debug(`${output}`);
-    output = this.getJsonFromOutput(output);
+    output = Tests.getJsonFromOutput(output);
     this.log.debug('Parsing the below JSON:');
     this.log.debug(`${output}`);
     let testMetadata;
@@ -116,7 +116,7 @@ export abstract class Tests {
    * @param output The output returned by running a command.
    * @return A string representation of the JSON found in the output.
    */
-  protected getJsonFromOutput(output: string): string {
+  static getJsonFromOutput(output: string): string {
     output = output.substring(output.indexOf('START_OF_TEST_JSON{'), output.lastIndexOf('}END_OF_TEST_JSON') + 1);
     // Get rid of the `START_OF_TEST_JSON` and `END_OF_TEST_JSON` to verify that the JSON is valid.
     return output.substring(output.indexOf("{"), output.lastIndexOf("}") + 1);
@@ -422,7 +422,7 @@ export abstract class Tests {
       this.testStatesEmitter.fire(<TestEvent>{ type: 'test', test: node.id, state: 'running' });
 
       let testOutput = await this.runFullTestSuite();
-      testOutput = this.getJsonFromOutput(testOutput);
+      testOutput = Tests.getJsonFromOutput(testOutput);
       this.log.debug('Parsing the below JSON:');
       this.log.debug(`${testOutput}`);
       let testMetadata = JSON.parse(testOutput);
@@ -441,7 +441,7 @@ export abstract class Tests {
 
       let testOutput = await this.runTestFile(`${node.file}`);
 
-      testOutput = this.getJsonFromOutput(testOutput);
+      testOutput = Tests.getJsonFromOutput(testOutput);
       this.log.debug('Parsing the below JSON:');
       this.log.debug(`${testOutput}`);
       let testMetadata = JSON.parse(testOutput);
@@ -473,7 +473,7 @@ export abstract class Tests {
         // VS Code and 1-indexed for RSpec/Minitest.
         let testOutput = await this.runSingleTest(`${node.file}:${node.line + 1}`);
 
-        testOutput = this.getJsonFromOutput(testOutput);
+        testOutput = Tests.getJsonFromOutput(testOutput);
         this.log.debug('Parsing the below JSON:');
         this.log.debug(`${testOutput}`);
         let testMetadata = JSON.parse(testOutput);


### PR DESCRIPTION
Now it'll show a warning message with a button, and if you click the button it'll open an output panel with the specific error message! :D

<img width="491" alt="Screen Shot 2020-02-12 at 8 47 22 PM" src="https://user-images.githubusercontent.com/2977353/74399715-efd1cc00-4dd8-11ea-9e09-0d9c59950d93.png">

<img width="1114" alt="Screen Shot 2020-02-12 at 8 46 15 PM" src="https://user-images.githubusercontent.com/2977353/74399665-c1ec8780-4dd8-11ea-9ee6-b8268e89405c.png">

It uses an output panel because VS Code doesn't allow newlines in error messages, so it's a lot harder to read if the error is embedded inside one.

Fixes #31.