### PR TITLE
Handle results with no klass property

### DIFF
--- a/ruby/vscode/minitest/reporter.rb
+++ b/ruby/vscode/minitest/reporter.rb
@@ -63,7 +63,8 @@ module VSCode
       end
 
       def vscode_result(r)
-        base = VSCode::Minitest.tests.find_by(klass: r.klass, method: r.name).dup
+        klass = r.respond_to?(:klass) ? r.klass : r.class.to_s
+        base = VSCode::Minitest.tests.find_by(klass: klass, method: r.name).dup
         if r.skipped?
           base[:status] = "failed"
           base[:pending_message] = r.failure.message

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -391,6 +391,10 @@ export abstract class Tests {
         resolve(data);
       }
     });
+    this.currentChildProcess.stderr!.pipe(split2()).on('data', (data) => {
+      data = data.toString();
+      this.log.debug(`[CHILD PROCESS STDERR], ${data}`);
+    });
   });
 
   /**


### PR DESCRIPTION
I'm not sure why my project test results don't have this property, but it was preventing the results from being displaying correctly because the ruby child would crash on this line. It works fine after these changes.