### PR TITLE
Supply file and line number to failed TestEvent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1162,9 +1162,9 @@
       }
     },
     "vscode-test-adapter-api": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-test-adapter-api/-/vscode-test-adapter-api-1.7.0.tgz",
-      "integrity": "sha512-X0rTcoDhDBmpmJuev2C5+GHGZD41nmcRYoSe7iw5e9/aIPTOFve1T1F5x9gb+zXoNQnkXSDibyMkeHDKtIkqCg=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/vscode-test-adapter-api/-/vscode-test-adapter-api-1.8.0.tgz",
+      "integrity": "sha512-sNSxc2ec0JHl7PACebJwg/Ew/3FiAXBndHDS4Zp27l893wdIyhSeZL9y7j57YV6dDUkNnaRg2QcyIIBvlk8obw=="
     },
     "vscode-test-adapter-util": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "split2": "^3.1.1",
     "tslib": "^1.10.0",
-    "vscode-test-adapter-api": "^1.7.0",
+    "vscode-test-adapter-api": "^1.8.0",
     "vscode-test-adapter-util": "^0.7.0"
   },
   "devDependencies": {

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -217,7 +217,8 @@ export class RspecTests extends Tests {
         decorations: [{
           // Strip line breaks from the message.
           message: errorMessageNoLinebreaks,
-          line: (fileBacktraceLineNumber ? fileBacktraceLineNumber : test.line_number) - 1
+          file: filePath,
+          line: (fileBacktraceLineNumber ? fileBacktraceLineNumber : test.line_number) - 1,
         }]
       });
     } else if (test.status === "failed" && test.pending_message !== null) {


### PR DESCRIPTION
When the TestEvent fires, it may contain a file name and a line number
to suggest where the event took place.

This commit adds the file name and line number to the TestEvent and to
its TestDecoration.