### PR TITLE
Do not replace underscores in test names that contain whitespace

### DIFF
--- a/ruby/vscode/minitest/tests.rb
+++ b/ruby/vscode/minitest/tests.rb
@@ -36,7 +36,7 @@ module VSCode
             path = full_path.gsub(VSCode.project_root.to_s, ".")
             path = "./#{path}" unless path.match?(/^\./)
             description = test_name.gsub(/^test_/, "")
-            description = description.match?(/\s/) ? description : description.tr("_", " ")
+            description = description.tr("_", " ") unless description.match?(/\s/)
 
             {
               description: description,

--- a/ruby/vscode/minitest/tests.rb
+++ b/ruby/vscode/minitest/tests.rb
@@ -35,9 +35,12 @@ module VSCode
             full_path = File.expand_path(path, VSCode.project_root)
             path = full_path.gsub(VSCode.project_root.to_s, ".")
             path = "./#{path}" unless path.match?(/^\./)
+            description = test_name.gsub(/^test_/, "")
+            description = description.match?(/\s/) ? description : description.tr("_", " ")
+
             {
-              description: test_name.gsub(/^test_/, "").tr("_", " "),
-              full_description: test_name.gsub(/^test_/, "").tr("_", " "),
+              description: description,
+              full_description: description,
               file_path: path,
               full_path: full_path,
               line_number: line,


### PR DESCRIPTION
This avoids modifying "nice" test descriptions provided by spec frameworks, e.g. "Object#some_method should return a value"