### PR TITLE
apply ruby.useBundler Option to execute bundler rdebug-ide

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -72,6 +72,7 @@ export class RubyAdapter implements TestAdapter {
     this.log.info(`Debugging test(s) ${JSON.stringify(testsToRun)} of ${this.workspace.uri.fsPath}`);
 
     const config = vscode.workspace.getConfiguration('rubyTestExplorer', null)
+    const rubyConfig = vscode.workspace.getConfiguration('ruby', null)
 
     const debuggerConfig = {
       name: "Debug Ruby Tests",
@@ -79,7 +80,8 @@ export class RubyAdapter implements TestAdapter {
       request: "attach",
       remoteHost: config.get('debuggerHost') || "127.0.0.1",
       remotePort: config.get('debuggerPort') || "1234",
-      remoteWorkspaceRoot: "${workspaceRoot}"
+      remoteWorkspaceRoot: "${workspaceRoot}",
+      useBundler: rubyConfig.get("useBundler") || false
     }
 
     const testRunPromise = this.run(testsToRun, debuggerConfig);

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -103,10 +103,18 @@ export class MinitestTests extends Tests {
   */
   protected testCommandWithDebugger(debuggerConfig?: vscode.DebugConfiguration): string {
     let cmd = `${this.getTestCommand()} vscode:minitest:run`
-    if (debuggerConfig) {
-      cmd = `rdebug-ide --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}`
-            + ` -- ${(process.platform == 'win32') ? '%EXT_DIR%' : '$EXT_DIR'}/debug_minitest.rb`
+
+    if (!debuggerConfig) {
+      return cmd
     }
+
+    cmd = `rdebug-ide --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}`
+          + ` -- ${(process.platform == 'win32') ? '%EXT_DIR%' : '$EXT_DIR'}/debug_minitest.rb`
+
+    if (debuggerConfig.useBundler) {
+      cmd = `bundle exec ${cmd}`
+    }
+    
     return cmd
   }
 


### PR DESCRIPTION
Hi

This PR is to execute "bundle exec rdebug-ide ..." using ruby.useBundler option.
