### PR TITLE
Feat: Add debugCommand configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Property                               | Description
 `rubyTestExplorer.filePattern`         | Define the pattern to match test files by, for example `["*_test.rb", "test_*.rb", "*_spec.rb"]`.
 `rubyTestExplorer.debuggerHost`        | Define the host to connect the debugger to, for example `127.0.0.1`.
 `rubyTestExplorer.debuggerPort`        | Define the port to connect the debugger to, for example `1234`.
+`rubyTestExplorer.debugCommand`        | Define how to run rdebug-ide, for example `rdebug-ide` or `bundle exec rdebug-ide`.
 `rubyTestExplorer.rspecCommand`        | Define the command to run RSpec tests with, for example `bundle exec rspec`, `spring rspec`, or `rspec`.
 `rubyTestExplorer.rspecDirectory`      | Define the relative directory of the specs in a given workspace, for example `./spec/`.
 `rubyTestExplorer.minitestCommand`     | Define how to run Minitest with Rake, for example `./bin/rake`, `bundle exec rake` or `rake`. Must be a Rake command.

--- a/package.json
+++ b/package.json
@@ -148,6 +148,12 @@
           "default": "1234",
           "type": "string",
           "scope": "resource"
+        },
+        "rubyTestExplorer.debugCommand": {
+          "markdownDescription": "Define how to run rdebug-ide, for example `rdebug-ide` or `bundle exec rdebug-ide`.",
+          "default": "rdebug-ide",
+          "type": "string",
+          "scope": "resource"
         }
       }
     }

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -63,6 +63,22 @@ export class MinitestTests extends Tests {
   }
 
   /**
+   * Get the user-configured rdebug-ide command, if there is one.
+   *
+   * @return The rdebug-ide command
+   */
+  protected getDebugCommand(debuggerConfig: vscode.DebugConfiguration): string {
+    let command: string =
+      (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('debugCommand') as string) ||
+      'rdebug-ide';
+
+    return (
+      `${command}  --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}` +
+      ` -- ${process.platform == 'win32' ? '%EXT_DIR%' : '$EXT_DIR'}/debug_minitest.rb`
+    );
+  }
+
+  /**
    * Get the user-configured test directory, if there is one.
    *
    * @return The test directory
@@ -104,10 +120,9 @@ export class MinitestTests extends Tests {
   protected testCommandWithDebugger(debuggerConfig?: vscode.DebugConfiguration): string {
     let cmd = `${this.getTestCommand()} vscode:minitest:run`
     if (debuggerConfig) {
-      cmd = `rdebug-ide --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}`
-            + ` -- ${(process.platform == 'win32') ? '%EXT_DIR%' : '$EXT_DIR'}/debug_minitest.rb`
+      cmd = this.getDebugCommand(debuggerConfig);
     }
-    return cmd
+    return cmd;
   }
 
   /**

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -81,6 +81,21 @@ export class RspecTests extends Tests {
   }
 
   /**
+   * Get the user-configured rdebug-ide command, if there is one.
+   *
+   * @return The rdebug-ide command
+   */
+  protected getDebugCommand(debuggerConfig: vscode.DebugConfiguration, args: string): string {
+    let command: string =
+      (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('debugCommand') as string) ||
+      'rdebug-ide';
+
+    return (
+      `${command} --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}` +
+      ` -- ${process.platform == 'win32' ? '%EXT_DIR%' : '$EXT_DIR'}/debug_rspec.rb ${args}`
+    );
+  }
+  /**
    * Get the user-configured RSpec command and add file pattern detection.
    *
    * @return The RSpec command
@@ -122,8 +137,7 @@ export class RspecTests extends Tests {
     let args = `--require ${this.getCustomFormatterLocation()} --format CustomFormatter`
     let cmd = `${this.getTestCommand()} ${args}`
     if (debuggerConfig) {
-      cmd = `rdebug-ide --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}`
-            + ` -- ${(process.platform == 'win32') ? '%EXT_DIR%' : '$EXT_DIR'}/debug_rspec.rb ${args}`
+      cmd = this.getDebugCommand(debuggerConfig, args);
     }
     return cmd
   }


### PR DESCRIPTION
Fixes: https://github.com/connorshea/vscode-ruby-test-adapter/issues/71 
(Alternatives to #69 and #59)

Allows you to configure your debug command and set it to eg. `bundle exec rdebug-id`.