### PR TITLE
Fix rspec tests by installing rspec Gemfile.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -5,4 +5,5 @@ set -vx
 
 npm install
 bundle install --gemfile=ruby/Gemfile
+bundle install --gemfile=test/fixtures/rspec/Gemfile
 bundle install --gemfile=test/fixtures/minitest/Gemfile


### PR DESCRIPTION
The only reason this worked was because the default ruby/Gemfile specified the latest versions for rspec, but that broke after rspec 3.11 came out in February lol

So this fixes that. Unfortunately not all the CI jobs are passing yet, but this at least fixes part of the problem...