### PR TITLE
Use default rspec pattern to enumerate tests

### DIFF
--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -105,7 +105,7 @@ export class RspecTests extends Tests {
   protected getTestCommandWithFilePattern(): string {
     let command: string = (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('rspecCommand') as string);
     const dir = this.getTestDirectory();
-    let pattern = this.getFilePattern().map(p => `${dir}/**/${p}`).join(',')
+    let pattern = this.getFilePattern().map(p => `${dir}/**{,/*/**}/${p}`).join(',')
     command = command || `bundle exec rspec`
     return `${command} --pattern '${pattern}'`;
   }


### PR DESCRIPTION
Notably, this pattern follows symlinks.

See https://relishapp.com/rspec/rspec-core/v/3-12/docs/command-line/pattern-option