### PR TITLE
Support debug gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ Property                               | Description
 `rubyTestExplorer.logfile`             | Write diagnostic logs to the given file.
 `rubyTestExplorer.testFramework`       | `none`, `auto`, `rspec`, or `minitest`. `auto` by default, which automatically detects the test framework based on the gems listed by Bundler. Can disable the extension functionality with `none` or set the test framework explicitly, if auto-detect isn't working properly.
 `rubyTestExplorer.filePattern`         | Define the pattern to match test files by, for example `["*_test.rb", "test_*.rb", "*_spec.rb"]`.
+`rubyTestExplorer.debugger`            | Which debugger to use. `rdebug-ide` or `rdbg`.
 `rubyTestExplorer.debuggerHost`        | Define the host to connect the debugger to, for example `127.0.0.1`.
 `rubyTestExplorer.debuggerPort`        | Define the port to connect the debugger to, for example `1234`.
 `rubyTestExplorer.debugCommand`        | Define how to run rdebug-ide, for example `rdebug-ide` or `bundle exec rdebug-ide`.
+`rubyTestExplorer.rdbgCommand`         | Define how to run rdbg, for example `rdbg` or `bundle exec rdbg`.
 `rubyTestExplorer.rspecCommand`        | Define the command to run RSpec tests with, for example `bundle exec rspec`, `spring rspec`, or `rspec`.
 `rubyTestExplorer.rspecDirectory`      | Define the relative directory of the specs in a given workspace, for example `./spec/`.
 `rubyTestExplorer.minitestCommand`     | Define how to run Minitest with Rake, for example `./bin/rake`, `bundle exec rake` or `rake`. Must be a Rake command.

--- a/package.json
+++ b/package.json
@@ -141,6 +141,20 @@
           },
           "scope": "resource"
         },
+        "rubyTestExplorer.debugger": {
+          "description": "Which debugger to use. `rdebug-ide` or `rdbg`.",
+          "type": "string",
+          "default": "rdebug-ide",
+          "enum": [
+            "rdebug-ide",
+            "rdbg"
+          ],
+          "enumDescriptions": [
+            "Use ruby-debug-ide gem.",
+            "Use debug gem."
+          ],
+          "scope": "resource"
+        },
         "rubyTestExplorer.debuggerHost": {
           "markdownDescription": "The host to connect the debugger to.",
           "default": "127.0.0.1",
@@ -156,6 +170,12 @@
         "rubyTestExplorer.debugCommand": {
           "markdownDescription": "Define how to run rdebug-ide, for example `rdebug-ide` or `bundle exec rdebug-ide`.",
           "default": "rdebug-ide",
+          "type": "string",
+          "scope": "resource"
+        },
+        "rubyTestExplorer.rdbgCommand": {
+          "markdownDescription": "Define how to run rdbg, for example `rdbg` or `bundle exec rdbg`.",
+          "default": "rdbg",
           "type": "string",
           "scope": "resource"
         }

--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -70,13 +70,9 @@ export class MinitestTests extends Tests {
    * @return The rdebug-ide command
    */
   protected getDebugCommand(debuggerConfig: vscode.DebugConfiguration): string {
-    let command: string =
-      (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('debugCommand') as string) ||
-      'rdebug-ide';
-
-    return (
-      `${command}  --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}` +
-      ` -- ${process.platform == 'win32' ? '%EXT_DIR%' : '$EXT_DIR'}/debug_minitest.rb`
+    return this.buildDebugCommand(
+      debuggerConfig,
+      `${process.platform == 'win32' ? '%EXT_DIR%' : '$EXT_DIR'}/debug_minitest.rb`
     );
   }
 

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -88,13 +88,10 @@ export class RspecTests extends Tests {
    * @return The rdebug-ide command
    */
   protected getDebugCommand(debuggerConfig: vscode.DebugConfiguration, args: string): string {
-    let command: string =
-      (vscode.workspace.getConfiguration('rubyTestExplorer', null).get('debugCommand') as string) ||
-      'rdebug-ide';
-
-    return (
-      `${command} --host ${debuggerConfig.remoteHost} --port ${debuggerConfig.remotePort}` +
-      ` -- ${process.platform == 'win32' ? '%EXT_DIR%' : '$EXT_DIR'}/debug_rspec.rb ${args}`
+    return this.buildDebugCommand(
+      debuggerConfig,
+      `${process.platform == 'win32' ? '%EXT_DIR%' : '$EXT_DIR'}/debug_rspec.rb`,
+      args
     );
   }
   /**

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -189,7 +189,8 @@ export class RspecTests extends Tests {
     this.log.info(`Running test file: ${testFile}`);
     const spawnArgs: childProcess.SpawnOptions = {
       cwd: this.workspace.uri.fsPath,
-      shell: true
+      shell: true,
+      env: this.getProcessEnv()
     };
 
     // Run tests for a given file at once with a single command.
@@ -214,7 +215,8 @@ export class RspecTests extends Tests {
     this.log.info(`Running full test suite.`);
     const spawnArgs: childProcess.SpawnOptions = {
       cwd: this.workspace.uri.fsPath,
-      shell: true
+      shell: true,
+      env: this.getProcessEnv()
     };
 
     let testCommand = this.testCommandWithFormatterAndDebugger(debuggerConfig);


### PR DESCRIPTION
This PR enables debug tests with [debug](https://github.com/ruby/debug) gem by using [vscode-rdbg](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension. (debug gem is bundled with Ruby 3.1+)

Users can choose which debugger to use by `rubyTestExplorer.debugger` configuration. (`rdebug-ide` or `rdbg`)

## Example

![image](https://user-images.githubusercontent.com/1477130/226609941-1050ad38-0e64-4733-be73-0f9d2c4cf66d.png)
