### PR TITLE
Added Default User Shell when executing Commands

### DIFF
--- a/src/minitestTests.ts
+++ b/src/minitestTests.ts
@@ -30,7 +30,9 @@ export class MinitestTests extends Tests {
    * @return The raw output from the Minitest JSON formatter.
    */
   initTests = async () => new Promise<string>((resolve, reject) => {
-    let cmd = `${this.getTestCommand()} vscode:minitest:list`;
+    let cmd = this.withDefaultShell(
+      `${this.getTestCommand()} vscode:minitest:list`
+    );
 
     // Allow a buffer of 64MB.
     const execArgs: childProcess.ExecOptions = {
@@ -144,7 +146,9 @@ export class MinitestTests extends Tests {
       env: this.getProcessEnv()
     };
 
-    let testCommand = `${this.testCommandWithDebugger(debuggerConfig)} '${relativeLocation}:${line}'`;
+    let testCommand = this.withDefaultShell(
+      `${this.testCommandWithDebugger(debuggerConfig)} '${relativeLocation}:${line}'`
+    );
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -172,7 +176,9 @@ export class MinitestTests extends Tests {
     };
 
     // Run tests for a given file at once with a single command.
-    let testCommand = `${this.testCommandWithDebugger(debuggerConfig)} '${relativeFile}'`;
+    let testCommand = this.withDefaultShell(
+      `${this.testCommandWithDebugger(debuggerConfig)} '${relativeFile}'`
+    );
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -197,7 +203,9 @@ export class MinitestTests extends Tests {
       env: this.getProcessEnv()
     };
 
-    let testCommand = this.testCommandWithDebugger(debuggerConfig);
+    let testCommand = this.withDefaultShell(
+      this.testCommandWithDebugger(debuggerConfig)
+    );
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(

--- a/src/rspecTests.ts
+++ b/src/rspecTests.ts
@@ -30,8 +30,13 @@ export class RspecTests extends Tests {
    * @return The raw output from the RSpec JSON formatter.
    */
   initTests = async () => new Promise<string>((resolve, reject) => {
-    let cmd = `${this.getTestCommandWithFilePattern()} --require ${this.getCustomFormatterLocation()}`
-              + ` --format CustomFormatter --order defined --dry-run`;
+    let cmd = this.withDefaultShell(
+      `${this.getTestCommandWithFilePattern()} \
+      --require ${this.getCustomFormatterLocation()} \
+      --format CustomFormatter \
+      --order defined \
+      --dry-run`
+    );
 
     this.log.info(`Running dry-run of RSpec test suite with the following command: ${cmd}`);
 
@@ -71,6 +76,7 @@ export class RspecTests extends Tests {
       resolve(stdout);
     });
   });
+
 
   /**
    * Get the user-configured RSpec command, if there is one.
@@ -170,7 +176,9 @@ export class RspecTests extends Tests {
       env: this.getProcessEnv()
     };
 
-    let testCommand = `${this.testCommandWithFormatterAndDebugger(debuggerConfig)} '${testLocation}'`;
+    let testCommand = this.withDefaultShell(
+      `${this.testCommandWithFormatterAndDebugger(debuggerConfig)} '${testLocation}'`
+    );
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -196,7 +204,9 @@ export class RspecTests extends Tests {
     };
 
     // Run tests for a given file at once with a single command.
-    let testCommand = `${this.testCommandWithFormatterAndDebugger(debuggerConfig)} '${testFile}'`;
+    let testCommand = this.withDefaultShell(
+      `${this.testCommandWithFormatterAndDebugger(debuggerConfig)} '${testFile}'`
+    );
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(
@@ -220,7 +230,9 @@ export class RspecTests extends Tests {
       shell: true
     };
 
-    let testCommand = this.testCommandWithFormatterAndDebugger(debuggerConfig);
+    let testCommand = this.withDefaultShell(
+      this.testCommandWithFormatterAndDebugger(debuggerConfig)
+    );
     this.log.info(`Running command: ${testCommand}`);
 
     let testProcess = childProcess.spawn(

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -13,6 +13,8 @@ export abstract class Tests {
   protected workspace: vscode.WorkspaceFolder;
   abstract testFrameworkName: string;
   protected debugCommandStartedResolver: Function | undefined;
+  // The path to the user's preferred command-line shell (like /bin/bash, /bin/zsh, etc.)
+  private readonly shell = process.env.SHELL?.replace(/(\s+)/g, "\\$1");
 
   /**
    * @param context Extension context provided by vscode.
@@ -518,6 +520,16 @@ export abstract class Tests {
   protected getRubyScriptsLocation(): string {
     return this.context.asAbsolutePath('./ruby');
   }
+
+  /**
+   * Wrap a command in the user's default shell (if there is one).
+   *
+   * @return The wrapped command (or the original command if there is no default shell)
+   */
+  protected withDefaultShell = (command: string) => {
+    return this.shell ? `${this.shell} -ic "${command}"` : command;
+  }
+
 
   /**
    * Runs a single test.


### PR DESCRIPTION
I was playing around with this extension, and for the most part, it works great. However, I ran into one issue: it did not use my default shell defined within the command line. This is a problem as I have some environment variables and path info that are not generally accessible to my other bash shells. This resulted in many please set `RAILS_MASTER_KEY` errors, which are easy to fix. However, it would not be nice to use my default shell when it detected it or others' default shells as this could save a lot of pain with differences in pathing info. 

This concept was pulled from [Ruby LSP](https://github.com/Shopify/vscode-ruby-lsp) so can't take credit for the code. 


```
[2023-12-19 22:54:55.246] [INFO] Running dry-run of RSpec test suite with the following command: /opt/homebrew/bin/fish -ic "bundle exec rspec --pattern './spec//**{,/*/**}/*_test.rb,./spec//**{,/*/**}/test_*.rb,./spec//**{,/*/**}/*_spec.rb'       --require /Users/brandit/apps/vscode-ruby-test-adapter/custom_formatter.rb       --format CustomFormatter       --order defined       --dry-run"
```

Above is the output it generates when I change the default shell to fishshell. This also works for zsh and bash. 


Some screenshots showing it working for rspec. 
![Screenshot 2023-12-19 at 3 19 34 PM](https://github.com/connorshea/vscode-ruby-test-adapter/assets/13140/bba6026f-45e4-425f-92da-b6186ea3b59d)


```
[2023-12-19 23:18:49.077] [INFO] Running command: /opt/homebrew/bin/fish -ic "bundle exec rspec --require /Users/brandit/apps/vscode-ruby-test-adapter/custom_formatter.rb --format CustomFormatter '/Users/brandit/apps/test/spec/testing_spec.rb:10'"
```
